### PR TITLE
VSEARCH app controller

### DIFF
--- a/bfillings/sortmerna_v2.py
+++ b/bfillings/sortmerna_v2.py
@@ -1,5 +1,13 @@
 #!/usr/bin/env python
 
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013--, biocore development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
 """
 Application controller for SortMeRNA version 2.0
 ================================================
@@ -15,7 +23,6 @@ Application controller for SortMeRNA version 2.0
 
 
 from os.path import split, splitext, dirname, join
-from os import getpid
 from glob import glob
 import re
 
@@ -105,7 +112,7 @@ def build_database_sortmerna(fasta_path,
         # so the app is not confused by relative paths
         fasta_path = fasta_filename
 
-    index_basename = "%s_%s" % (splitext(fasta_filename)[0], getpid())
+    index_basename = splitext(fasta_filename)[0]
 
     db_name = join(output_dir, index_basename)
 
@@ -295,7 +302,6 @@ def sortmerna_ref_cluster(seq_path=None,
                           coverage=0.97,
                           threads=1,
                           best=1,
-                          aligned='sortmerna_results',
                           HALT_EXEC=False
                           ):
     """Launch sortmerna OTU picker
@@ -322,9 +328,7 @@ def sortmerna_ref_cluster(seq_path=None,
             output BLAST tabular alignments [default: False].
         best : int, optional
             number of best alignments to output per read
-            [default: 1]
-        aligned : str, optional
-            base name for --aligned output files
+            [default: 1].
 
         Returns
         -------
@@ -358,7 +362,7 @@ def sortmerna_ref_cluster(seq_path=None,
     # Set output results path (for Blast alignments, clusters and failures)
     output_dir = dirname(result_path)
     if output_dir is not None:
-        output_file = join(output_dir, aligned)
+        output_file = join(output_dir, "sortmerna_otus")
         smr.Parameters['--aligned'].on(output_file)
 
     # Set E-value threshold

--- a/bfillings/sortmerna_v2.py
+++ b/bfillings/sortmerna_v2.py
@@ -295,7 +295,7 @@ def sortmerna_ref_cluster(seq_path=None,
                           coverage=0.97,
                           threads=1,
                           best=1,
-                          aligned=None,
+                          aligned='sortmerna_results',
                           HALT_EXEC=False
                           ):
     """Launch sortmerna OTU picker
@@ -322,7 +322,9 @@ def sortmerna_ref_cluster(seq_path=None,
             output BLAST tabular alignments [default: False].
         best : int, optional
             number of best alignments to output per read
-            [default: 1].
+            [default: 1]
+        aligned : str, optional
+            base name for --aligned output files
 
         Returns
         -------
@@ -356,11 +358,7 @@ def sortmerna_ref_cluster(seq_path=None,
     # Set output results path (for Blast alignments, clusters and failures)
     output_dir = dirname(result_path)
     if output_dir is not None:
-        if aligned == None:
-            aligned_str = "sortmerna_results"
-        else:
-            aligned_str = aligned
-        output_file = join(output_dir, aligned_str)
+        output_file = join(output_dir, aligned)
         smr.Parameters['--aligned'].on(output_file)
 
     # Set E-value threshold

--- a/bfillings/sortmerna_v2.py
+++ b/bfillings/sortmerna_v2.py
@@ -15,6 +15,7 @@ Application controller for SortMeRNA version 2.0
 
 
 from os.path import split, splitext, dirname, join
+from os import getpid
 from glob import glob
 import re
 
@@ -104,11 +105,7 @@ def build_database_sortmerna(fasta_path,
         # so the app is not confused by relative paths
         fasta_path = fasta_filename
 
-    index_basename = mkdtemp(dir=output_dir,
-                             prefix=splitext(fasta_filename)[0],
-                             suffix='')
-
-    #index_basename = splitext(fasta_filename)[0]
+    index_basename = "%s_%s" % (splitext(fasta_filename)[0], getpid())
 
     db_name = join(output_dir, index_basename)
 
@@ -360,7 +357,7 @@ def sortmerna_ref_cluster(seq_path=None,
     output_dir = dirname(result_path)
     if output_dir is not None:
         if aligned == None:
-            aligned_str = "sortmerna_otus"
+            aligned_str = "sortmerna_results"
         else:
             aligned_str = aligned
         output_file = join(output_dir, aligned_str)

--- a/bfillings/sortmerna_v2.py
+++ b/bfillings/sortmerna_v2.py
@@ -104,7 +104,11 @@ def build_database_sortmerna(fasta_path,
         # so the app is not confused by relative paths
         fasta_path = fasta_filename
 
-    index_basename = splitext(fasta_filename)[0]
+    index_basename = mkdtemp(dir=output_dir,
+                             prefix=splitext(fasta_filename)[0],
+                             suffix='')
+
+    #index_basename = splitext(fasta_filename)[0]
 
     db_name = join(output_dir, index_basename)
 

--- a/bfillings/sortmerna_v2.py
+++ b/bfillings/sortmerna_v2.py
@@ -1,13 +1,5 @@
 #!/usr/bin/env python
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013--, biocore development team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
-
 """
 Application controller for SortMeRNA version 2.0
 ================================================
@@ -302,6 +294,7 @@ def sortmerna_ref_cluster(seq_path=None,
                           coverage=0.97,
                           threads=1,
                           best=1,
+                          aligned=None,
                           HALT_EXEC=False
                           ):
     """Launch sortmerna OTU picker
@@ -362,7 +355,11 @@ def sortmerna_ref_cluster(seq_path=None,
     # Set output results path (for Blast alignments, clusters and failures)
     output_dir = dirname(result_path)
     if output_dir is not None:
-        output_file = join(output_dir, "sortmerna_otus")
+        if aligned == None:
+            aligned_str = "sortmerna_otus"
+        else:
+            aligned_str = aligned
+        output_file = join(output_dir, aligned_str)
         smr.Parameters['--aligned'].on(output_file)
 
     # Set E-value threshold

--- a/bfillings/tests/test_vsearch.py
+++ b/bfillings/tests/test_vsearch.py
@@ -1,0 +1,1666 @@
+#!/usr/bin/env python
+
+#-----------------------------------------------------------------------------
+# Copyright (c) 2015--, biocore development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+"""
+Unit tests for the VSEARCH version 1.0.7 Application controller
+===============================================================
+"""
+
+
+from unittest import TestCase, main
+import re
+from os import close
+from os.path import abspath, exists, join, dirname
+from tempfile import mkstemp, mkdtemp
+from shutil import rmtree
+
+from skbio.util import remove_files
+from skbio.parse.sequences import parse_fasta
+
+from bfillings.vsearch import (vsearch_dereplicate_exact_seqs,
+                               vsearch_sort_by_abundance,
+                               vsearch_chimera_filter_de_novo,
+                               vsearch_chimera_filter_ref)
+
+
+# Test class and cases
+class VsearchTests(TestCase):
+    """ Tests for VSEARCH version 1.0.7 functionality """
+
+    def setUp(self):
+        self.output_dir = mkdtemp()
+        self.seqs_to_derep = seqs_to_derep
+        self.seqs_to_derep_max_min_abundance = seqs_to_derep_max_min_abundance
+        self.seqs_to_derep_merged_derep_files = seqs_to_derep_merged_derep_files
+        self.seqs_to_sort = seqs_to_sort
+        self.amplicon_reads = amplicon_reads
+        self.single_chimera = single_chimera 
+        self.single_chimera_ref = single_chimera_ref
+        self.uchime_ref_db = uchime_ref_db
+        self.uchime_single_ref_db = uchime_single_ref_db
+
+        # temporary file for seqs_to_derep
+        f, self.seqs_to_derep_fp = mkstemp(prefix='tmp_seqs_to_derep_',
+                                           suffix='.fasta')
+        close(f)
+
+        # write seqs_to_derep to file
+        with open(self.seqs_to_derep_fp, 'w') as tmp:
+            tmp.write(self.seqs_to_derep)
+
+        # temporary file for seqs_to_derep_max_min_abundance
+        f, self.seqs_to_derep_max_min_abundance_fp = mkstemp(prefix='tmp_seqs_to_derep_abun_',
+                                                             suffix='.fasta')
+        close(f)
+
+        # write seqs_to_derep_max_min_abundance to file
+        with open(self.seqs_to_derep_max_min_abundance_fp, 'w') as tmp:
+            tmp.write(self.seqs_to_derep_max_min_abundance)
+
+        # temporary file for seqs_to_derep_merged_derep_files
+        f, self.seqs_to_derep_merged_derep_files_fp = mkstemp(prefix='tmp_seqs_to_derep_concat_',
+                                                              suffix='.fasta')
+        close(f)
+
+        # write seqs_to_derep_merged_derep_files to file
+        with open(self.seqs_to_derep_merged_derep_files_fp, 'w') as tmp:
+            tmp.write(self.seqs_to_derep_merged_derep_files)
+
+        # temporary file for seqs_to_sort
+        f, self.seqs_to_sort_fp = mkstemp(prefix='tmp_seqs_to_sort_',
+                                          suffix='.fasta')
+        close(f)
+
+        # write seqs_to_sort to file
+        with open(self.seqs_to_sort_fp, 'w') as tmp:
+            tmp.write(self.seqs_to_sort)
+
+        # temporary file for amplicon_reads
+        f, self.amplicon_reads_fp = mkstemp(prefix='tmp_amplicon_reads_',
+                                            suffix='.fasta')
+        close(f)
+
+        # write amplicon_reads to file
+        with open(self.amplicon_reads_fp, 'w') as tmp:
+            tmp.write(self.amplicon_reads)
+
+        # temporary file for single_chimera
+        f, self.single_chimera_fp = mkstemp(prefix='tmp_single_chimera_',
+                                            suffix='.fasta')
+        close(f)
+
+        # write single_chimera to file
+        # (de novo chimera checking)
+        with open(self.single_chimera_fp, 'w') as tmp:
+            tmp.write(self.single_chimera)
+
+        # temporary file for single_chimera_ref
+        f, self.single_chimera_ref_fp = mkstemp(prefix='tmp_single_chimera_',
+                                                suffix='.fasta')
+        close(f)
+        
+        # write single_chimera_ref to file
+        # (reference chimera checking)
+        with open(self.single_chimera_ref_fp, 'w') as tmp:
+            tmp.write(self.single_chimera_ref)
+
+        # temporary file for uchime_ref_db
+        f, self.uchime_ref_db_fp = mkstemp(prefix='tmp_uchime_ref_db_',
+                                           suffix='.fasta')
+        close(f)
+
+        # write uchime_ref_db to file
+        with open(self.uchime_ref_db_fp, 'w') as tmp:
+            tmp.write(self.uchime_ref_db)
+    
+        # temporary file for uchime_single_ref_db
+        f, self.uchime_single_ref_db_fp = mkstemp(prefix='tmp_uchime_single_ref_db_',
+                                                  suffix='.fasta')
+        close(f)
+
+        # write uchime_single_ref_db to file
+        with open(self.uchime_single_ref_db_fp, 'w') as tmp:
+            tmp.write(self.uchime_single_ref_db)
+
+        # list of files to remove
+        self.files_to_remove = [self.seqs_to_derep_fp,
+                                self.seqs_to_derep_max_min_abundance_fp,
+                                self.seqs_to_derep_merged_derep_files_fp,
+                                self.seqs_to_sort_fp,
+                                self.amplicon_reads_fp,
+                                self.single_chimera_fp,
+                                self.single_chimera_ref_fp,
+                                self.uchime_ref_db_fp,
+                                self.uchime_single_ref_db_fp]
+
+    def tearDown(self):
+        remove_files(self.files_to_remove)
+        rmtree(self.output_dir)
+
+    def test_vsearch_chimera_filter_ref(self):
+        """ Test reference chimera filter, output only
+            chimeric sequences
+        """
+        chimeras_fp, nonchimeras_fp, alns_fp, tabular_fp =\
+            vsearch_chimera_filter_ref(
+            self.amplicon_reads_fp,
+            self.output_dir,
+            self.uchime_ref_db_fp,
+            output_chimeras=True,
+            output_nonchimeras=False,
+            output_alns=False,
+            output_tabular=False,
+            log_name="vsearch_uchime_ref_chimera_filtering.log",
+            HALT_EXEC=False)
+
+        self.assertTrue(nonchimeras_fp is None)
+        self.assertTrue(alns_fp is None)
+        self.assertTrue(tabular_fp is None)
+
+        expected_chimeras = ['251;size=2;', '320;size=2;', '36;size=2;',
+                             '672;size=2;', '142;size=1;', '201;size=1;',
+                             '241;size=1;', '279;size=1;', '299;size=1;',
+                             '359;size=1;', '375;size=1;', '407;size=1;',
+                             '423;size=1;', '516;size=1;', '618;size=1;',
+                             '717;size=1;', '902;size=1;', '918;size=1;',
+                             '941;size=1;']
+
+        num_seqs = 0
+
+        with open(chimeras_fp, "U") as chimeras_f:
+            for label, seq in parse_fasta(chimeras_f):
+                # check label represents chimeric sequence
+                self.assertTrue(label in expected_chimeras)
+                # check sequence exists
+                self.assertTrue(len(seq) > 0)
+                num_seqs += 1
+
+        self.assertTrue(num_seqs, 19)
+
+    def test_vsearch_chimera_filter_ref_output(self):
+        """ Raise error when no output is selected for
+            reference chimera filtering 
+        """
+
+        self.assertRaises(ValueError,
+                          vsearch_chimera_filter_ref,
+                          fasta_filepath=self.amplicon_reads_fp,
+                          working_dir=self.output_dir,
+                          db_filepath=self.uchime_ref_db_fp,
+                          output_chimeras=False,
+                          output_nonchimeras=False,
+                          output_alns=False,
+                          output_tabular=False,
+                          log_name="vsearch_uchime_ref_chimera_filtering.log",
+                          HALT_EXEC=False)
+
+    def test_vsearch_chimera_filter_ref_output_nonchimeras(self):
+        """ Test ref chimera filter, output nonchimeric sequences                                                               
+        """
+        chimeras_fp, nonchimeras_fp, alns_fp, tabular_fp =\
+            vsearch_chimera_filter_ref(
+            self.amplicon_reads_fp,
+            self.output_dir,
+            self.uchime_ref_db_fp,
+            output_chimeras=False,
+            output_nonchimeras=True,
+            output_alns=False,
+            output_tabular=False,
+            log_name="vsearch_uchime_ref_chimera_filtering.log",
+            HALT_EXEC=False)
+
+        self.assertTrue(chimeras_fp is None)
+        self.assertTrue(alns_fp is None)
+        self.assertTrue(tabular_fp is None)
+
+        expected_nonchimeras =\
+            ['3;size=102;', '16;size=95;', '22;size=93;', '2;size=87;', '39;size=84;',
+             '4;size=79;', '6;size=72;', '11;size=70;', '45;size=67;', '1;size=65;',
+             '425;size=2;', '100;size=1;', '102;size=1;', '10;size=1;', '115;size=1;',
+             '123;size=1;', '132;size=1;', '134;size=1;', '140;size=1;', '144;size=1;',
+             '148;size=1;', '14;size=1;', '156;size=1;', '15;size=1;', '161;size=1;',
+             '162;size=1;', '186;size=1;', '203;size=1;', '217;size=1;', '218;size=1;',
+             '21;size=1;', '221;size=1;', '222;size=1;', '225;size=1;', '233;size=1;',
+             '234;size=1;', '235;size=1;', '249;size=1;', '24;size=1;', '259;size=1;',
+             '266;size=1;', '26;size=1;', '27;size=1;', '296;size=1;', '303;size=1;',
+             '306;size=1;', '307;size=1;', '322;size=1;', '326;size=1;', '32;size=1;',
+             '332;size=1;', '333;size=1;', '338;size=1;', '360;size=1;', '362;size=1;',
+             '364;size=1;', '366;size=1;', '369;size=1;', '371;size=1;', '373;size=1;',
+             '374;size=1;', '37;size=1;', '386;size=1;', '387;size=1;', '392;size=1;',
+             '393;size=1;', '397;size=1;', '405;size=1;', '414;size=1;', '418;size=1;',
+             '431;size=1;', '436;size=1;', '444;size=1;', '445;size=1;', '456;size=1;',
+             '460;size=1;', '469;size=1;', '470;size=1;', '477;size=1;', '479;size=1;',
+             '486;size=1;', '500;size=1;', '515;size=1;', '528;size=1;', '530;size=1;',
+             '531;size=1;', '549;size=1;', '551;size=1;', '557;size=1;', '559;size=1;',
+             '561;size=1;', '562;size=1;', '564;size=1;', '566;size=1;', '568;size=1;',
+             '570;size=1;', '578;size=1;', '57;size=1;', '586;size=1;', '596;size=1;',
+             '600;size=1;', '612;size=1;', '625;size=1;', '632;size=1;', '649;size=1;',
+             '650;size=1;', '651;size=1;', '664;size=1;', '66;size=1;', '673;size=1;',
+             '675;size=1;', '682;size=1;', '690;size=1;', '699;size=1;', '709;size=1;',
+             '73;size=1;', '740;size=1;', '745;size=1;', '746;size=1;', '748;size=1;',
+             '760;size=1;', '766;size=1;', '778;size=1;', '77;size=1;', '791;size=1;',
+             '797;size=1;', '7;size=1;', '809;size=1;', '813;size=1;', '814;size=1;',
+             '816;size=1;', '817;size=1;', '821;size=1;', '824;size=1;', '827;size=1;',
+             '82;size=1;', '83;size=1;', '842;size=1;', '851;size=1;', '853;size=1;',
+             '862;size=1;', '863;size=1;', '866;size=1;', '871;size=1;', '879;size=1;',
+             '886;size=1;', '892;size=1;', '895;size=1;', '897;size=1;', '904;size=1;',
+             '912;size=1;', '916;size=1;', '91;size=1;', '920;size=1;', '921;size=1;',
+             '925;size=1;', '930;size=1;', '942;size=1;', '945;size=1;', '947;size=1;',
+             '948;size=1;', '952;size=1;', '956;size=1;', '958;size=1;', '964;size=1;',
+             '967;size=1;', '984;size=1;', '992;size=1;', '993;size=1;']
+
+        num_seqs = 0
+
+        # check nonchimeras fasta file
+        with open(nonchimeras_fp, "U") as nonchimeras_f:
+            for label, seq in parse_fasta(nonchimeras_f):
+                # check label represents chimeric sequence
+                self.assertTrue(label in expected_nonchimeras)
+                # check sequence exists
+                self.assertTrue(len(seq) > 0)
+                num_seqs += 1
+
+        self.assertTrue(num_seqs, 169)
+
+    def test_vsearch_chimera_filter_ref_output_alns_tab(self):
+        """ Test ref chimera filter, output only
+            chimeric alignments and tabular format
+        """
+        chimeras_fp, nonchimeras_fp, alns_fp, tabular_fp =\
+            vsearch_chimera_filter_ref(
+            self.single_chimera_ref_fp,
+            self.output_dir,
+            self.uchime_single_ref_db_fp,
+            output_chimeras=False,
+            output_nonchimeras=False,
+            output_alns=True,
+            output_tabular=True,
+            log_name="vsearch_uchime_ref_chimera_filtering.log",
+            HALT_EXEC=False)
+
+        self.assertTrue(chimeras_fp is None)
+        self.assertTrue(nonchimeras_fp is None)
+
+        # check alignment is correct
+        with open(alns_fp, 'U') as alns_f:
+            actual_alns = alns_f.read()
+        self.assertEquals(single_chimera_ref_aln, actual_alns)
+
+        # check tabular output is correct
+        with open(tabular_fp, 'U') as tabular_f:
+            actual_tab = tabular_f.read()
+
+        self.assertEquals(single_chimera_ref_tab, actual_tab)
+
+    def test_vsearch_chimera_filter_de_novo(self):
+        """ Test de novo chimera filter, output only
+            chimeric sequences
+        """
+        chimeras_fp, nonchimeras_fp, alns_fp, tabular_fp =\
+            vsearch_chimera_filter_de_novo(
+            self.amplicon_reads_fp,
+            self.output_dir,
+            output_chimeras=True,
+            output_nonchimeras=False,
+            output_alns=False,
+            output_tabular=False,
+            log_name="vsearch_uchime_de_novo_chimera_filtering.log",
+            HALT_EXEC=False)
+
+        self.assertTrue(nonchimeras_fp is None)
+        self.assertTrue(alns_fp is None)
+        self.assertTrue(tabular_fp is None)
+
+        expected_chimeras = ['251;size=2;', '320;size=2;', '36;size=2;',
+                             '672;size=2;', '142;size=1;', '201;size=1;',
+                             '241;size=1;', '279;size=1;', '299;size=1;',
+                             '359;size=1;', '375;size=1;', '407;size=1;',
+                             '423;size=1;', '516;size=1;', '618;size=1;',
+                             '717;size=1;', '902;size=1;', '918;size=1;',
+                             '941;size=1;']
+
+        num_seqs = 0
+
+        with open(chimeras_fp, "U") as chimeras_f:
+            for label, seq in parse_fasta(chimeras_f):
+                # check label represents chimeric sequence                                                           
+                self.assertTrue(label in expected_chimeras)
+                # check sequence exists
+                self.assertTrue(len(seq) > 0)
+                num_seqs += 1
+
+        self.assertTrue(num_seqs, 19)
+
+    def test_vsearch_chimera_filter_de_novo_output(self):
+        """ Raise error when no output is selected for
+            de novo chimera filtering
+        """
+
+        self.assertRaises(ValueError,
+                          vsearch_chimera_filter_de_novo,
+                          fasta_filepath=self.amplicon_reads_fp,
+                          working_dir=self.output_dir,
+                          output_chimeras=False,
+                          output_nonchimeras=False,
+                          output_alns=False,
+                          output_tabular=False,
+                          log_name="vsearch_uchime_de_novo_chimera_filtering.log",
+                          HALT_EXEC=False)
+
+    def test_vsearch_chimera_filter_de_novo_output_nonchimeras(self):
+        """ Test de novo chimera filter, output nonchimeric sequences
+        """
+        chimeras_fp, nonchimeras_fp, alns_fp, tabular_fp =\
+            vsearch_chimera_filter_de_novo(
+            self.amplicon_reads_fp,
+            self.output_dir,
+            output_chimeras=False,
+            output_nonchimeras=True,
+            output_alns=False,
+            output_tabular=False,
+            log_name="vsearch_uchime_de_novo_chimera_filtering.log",
+            HALT_EXEC=False)
+
+        self.assertTrue(chimeras_fp is None)
+        self.assertTrue(alns_fp is None)
+        self.assertTrue(tabular_fp is None)
+
+        expected_nonchimeras =\
+            ['3;size=102;', '16;size=95;', '22;size=93;', '2;size=87;', '39;size=84;',
+             '4;size=79;', '6;size=72;', '11;size=70;', '45;size=67;', '1;size=65;',
+             '425;size=2;', '100;size=1;', '102;size=1;', '10;size=1;', '115;size=1;',
+             '123;size=1;', '132;size=1;', '134;size=1;', '140;size=1;', '144;size=1;',
+             '148;size=1;', '14;size=1;', '156;size=1;', '15;size=1;', '161;size=1;',
+             '162;size=1;', '186;size=1;', '203;size=1;', '217;size=1;', '218;size=1;',
+             '21;size=1;', '221;size=1;', '222;size=1;', '225;size=1;', '233;size=1;',
+             '234;size=1;', '235;size=1;', '249;size=1;', '24;size=1;', '259;size=1;',
+             '266;size=1;', '26;size=1;', '27;size=1;', '296;size=1;', '303;size=1;',
+             '306;size=1;', '307;size=1;', '322;size=1;', '326;size=1;', '32;size=1;',
+             '332;size=1;', '333;size=1;', '338;size=1;', '360;size=1;', '362;size=1;',
+             '364;size=1;', '366;size=1;', '369;size=1;', '371;size=1;', '373;size=1;',
+             '374;size=1;', '37;size=1;', '386;size=1;', '387;size=1;', '392;size=1;',
+             '393;size=1;', '397;size=1;', '405;size=1;', '414;size=1;', '418;size=1;',
+             '431;size=1;', '436;size=1;', '444;size=1;', '445;size=1;', '456;size=1;',
+             '460;size=1;', '469;size=1;', '470;size=1;', '477;size=1;', '479;size=1;',
+             '486;size=1;', '500;size=1;', '515;size=1;', '528;size=1;', '530;size=1;',
+             '531;size=1;', '549;size=1;', '551;size=1;', '557;size=1;', '559;size=1;',
+             '561;size=1;', '562;size=1;', '564;size=1;', '566;size=1;', '568;size=1;',
+             '570;size=1;', '578;size=1;', '57;size=1;', '586;size=1;', '596;size=1;',
+             '600;size=1;', '612;size=1;', '625;size=1;', '632;size=1;', '649;size=1;',
+             '650;size=1;', '651;size=1;', '664;size=1;', '66;size=1;', '673;size=1;',
+             '675;size=1;', '682;size=1;', '690;size=1;', '699;size=1;', '709;size=1;',
+             '73;size=1;', '740;size=1;', '745;size=1;', '746;size=1;', '748;size=1;',
+             '760;size=1;', '766;size=1;', '778;size=1;', '77;size=1;', '791;size=1;',
+             '797;size=1;', '7;size=1;', '809;size=1;', '813;size=1;', '814;size=1;',
+             '816;size=1;', '817;size=1;', '821;size=1;', '824;size=1;', '827;size=1;',
+             '82;size=1;', '83;size=1;', '842;size=1;', '851;size=1;', '853;size=1;',
+             '862;size=1;', '863;size=1;', '866;size=1;', '871;size=1;', '879;size=1;',
+             '886;size=1;', '892;size=1;', '895;size=1;', '897;size=1;', '904;size=1;',
+             '912;size=1;', '916;size=1;', '91;size=1;', '920;size=1;', '921;size=1;',
+             '925;size=1;', '930;size=1;', '942;size=1;', '945;size=1;', '947;size=1;',
+             '948;size=1;', '952;size=1;', '956;size=1;', '958;size=1;', '964;size=1;',
+             '967;size=1;', '984;size=1;', '992;size=1;', '993;size=1;']
+
+        num_seqs = 0
+
+        # check nonchimeras fasta file
+        with open(nonchimeras_fp, "U") as nonchimeras_f:
+            for label, seq in parse_fasta(nonchimeras_f):
+                # check label represents chimeric sequence
+                self.assertTrue(label in expected_nonchimeras)
+                # check sequence exists
+                self.assertTrue(len(seq) > 0)
+                num_seqs += 1
+
+        self.assertTrue(num_seqs, 169)
+
+    def test_vsearch_chimera_filter_de_novo_output_alns_tab(self):
+        """ Test de novo chimera filter, output only
+            chimeric alignments and tabular format                                                  
+        """
+        chimeras_fp, nonchimeras_fp, alns_fp, tabular_fp =\
+            vsearch_chimera_filter_de_novo(
+            self.single_chimera_fp,
+            self.output_dir,
+            output_chimeras=False,
+            output_nonchimeras=False,
+            output_alns=True,
+            output_tabular=True,
+            log_name="vsearch_uchime_de_novo_chimera_filtering.log",
+            HALT_EXEC=False)
+
+        self.assertTrue(chimeras_fp is None)
+        self.assertTrue(nonchimeras_fp is None)
+
+        # check alignment is correct
+        with open(alns_fp, 'U') as alns_f:
+            actual_alns = alns_f.read()
+        self.assertEquals(single_chimera_aln, actual_alns)
+
+        # check tabular output is correct
+        with open(tabular_fp, 'U') as tabular_f:
+            actual_tab = tabular_f.read()
+        self.assertEquals(single_chimera_tab, actual_tab)
+
+    def test_vsearch_sort_by_abundance(self):
+        """ Test sorting sequences by abundance                                                        
+        """
+        tmp_fp = join(self.output_dir, "tmp_sorted_reads.fasta")
+
+        output_sorted = vsearch_sort_by_abundance(
+            self.seqs_to_sort_fp,
+            tmp_fp,
+            working_dir=None,
+            minsize=None,
+            maxsize=None,
+            log_name="abundance_sort.log",
+            HALT_EXEC=False)
+
+        expected_order = ['HWI-ST157_0368:1:2107:19923:3944#0/1;size=100;',
+                          'HWI-ST157_0368:1:1201:8401:113582#0/1;size=10;',
+                          'HWI-ST157_0368:1:2204:20491:181552#0/1;size=10;',
+                          'HWI-ST157_0368:1:2105:3428:36721#0/1;size=5;',
+                          'HWI-ST157_0368:1:2105:6731:137157#0/1;size=4;',
+                          'HWI-ST157_0368:1:2106:18272:88408#0/1;size=2;',
+                          'HWI-ST157_0368:1:1106:12200:200135#0/1;size=1;',
+                          'HWI-ST157_0368:1:2208:9135:145970#0/1;size=1;']
+
+        num_seqs = 0
+
+        with open(tmp_fp, "U") as tmp_f:
+            for label, seq in parse_fasta(tmp_f):
+                # check label is in correct order
+                self.assertEquals(label, expected_order[num_seqs])
+                # check sequence exists
+                self.assertTrue(len(seq) > 0)
+                num_seqs += 1
+
+        self.assertTrue(num_seqs, 8)
+        
+    def test_vsearch_sort_by_abundance_minsize_1_maxsize_10(self):
+        """ Test sorting sequences by abundance,
+            discard sequences with an abundance value smaller
+            than 1 and greater than 10
+        """
+        tmp_fp = join(self.output_dir, "tmp_sorted_reads.fasta")
+
+        output_sorted = vsearch_sort_by_abundance(
+            self.seqs_to_sort_fp,
+            tmp_fp,
+            working_dir=None,
+            minsize=2,
+            maxsize=10,
+            log_name="abundance_sort.log",
+            HALT_EXEC=False)
+
+        expected_order = ['HWI-ST157_0368:1:1201:8401:113582#0/1;size=10;',
+                          'HWI-ST157_0368:1:2204:20491:181552#0/1;size=10;',
+                          'HWI-ST157_0368:1:2105:3428:36721#0/1;size=5;',
+                          'HWI-ST157_0368:1:2105:6731:137157#0/1;size=4;',
+                          'HWI-ST157_0368:1:2106:18272:88408#0/1;size=2;']
+
+        num_seqs = 0
+
+        with open(tmp_fp, "U") as tmp_f:
+            for label, seq in parse_fasta(tmp_f):
+                # check label is in correct order                                                                                    
+                self.assertEquals(label, expected_order[num_seqs])
+                # check sequence exists                                                                                              
+                self.assertTrue(len(seq) > 0)
+                num_seqs += 1
+
+        self.assertTrue(num_seqs, 5)
+
+    def test_vsearch_dereplicate_exact_seqs(self):
+    	""" Test dereplicating sequences
+        """
+        tmp_fp = join(self.output_dir, "tmp_derep_reads.fasta")
+
+        dereplicated_seqs_fp, uc_fp = vsearch_dereplicate_exact_seqs(
+            self.seqs_to_derep_fp,
+            tmp_fp,
+            output_uc=False,
+            working_dir=self.output_dir,
+            strand="both",
+            maxuniquesize=None,
+            minuniquesize=None,
+            sizein=False,
+            sizeout=True)
+
+        # no output for .uc
+        self.assertTrue(uc_fp is None)
+
+        num_seqs = 0
+        expected_derep = ['HWI-ST157_0368:1:1207:16180:126921#0/1;size=3;',
+                          'HWI-ST157_0368:1:2103:7895:197066#0/1;size=3;',
+                          'HWI-ST157_0368:1:1106:11378:83198#0/1;size=1;',
+                          'HWI-ST157_0368:1:2102:15078:69955#0/1;size=1;']
+
+        with open(tmp_fp, "U") as tmp_f:
+            for label, seq in parse_fasta(tmp_f):
+                num_seqs += 1
+                # check output labels are correct
+                self.assertTrue(label in expected_derep)
+                # check sequence exists
+                self.assertTrue(len(seq) > 0)
+
+        # check there are 4 sequences after dereplication
+        self.assertEquals(num_seqs, 4)
+
+    def test_vsearch_dereplicate_exact_seqs_uc(self):
+        """ Test dereplicating sequences with .uc output
+        """
+        tmp_fp = join(self.output_dir, "tmp_derep_reads.fasta")
+
+        dereplicated_seqs_fp, uc_fp = vsearch_dereplicate_exact_seqs(
+            self.seqs_to_derep_fp,
+            tmp_fp,
+            output_uc=True,
+            working_dir=self.output_dir,
+            strand="both",
+            maxuniquesize=None,
+            minuniquesize=None,
+            sizein=False,
+            sizeout=True)
+
+        # .uc exists
+        self.assertTrue(exists(uc_fp))
+
+        id_to_count = {}
+
+        num_seqs = 0
+        expected_derep = {'HWI-ST157_0368:1:1207:16180:126921#0/1':3,
+                          'HWI-ST157_0368:1:2103:7895:197066#0/1':3,
+                          'HWI-ST157_0368:1:1106:11378:83198#0/1':1,
+                          'HWI-ST157_0368:1:2102:15078:69955#0/1':1}
+
+        with open(uc_fp, 'U') as uc_f:
+            for line in uc_f:
+                if line.startswith('S'):
+                    num_seqs += 1
+                    label = line.strip().split('\t')[8]
+                    # check output labels are correct
+                    self.assertTrue(label in expected_derep)
+                    id_to_count[label] = 1
+                elif line.startswith('H'):
+                    seed = line.strip().split('\t')[9]
+                    id_to_count[seed] += 1
+                    
+        # check there are 4 sequences after dereplication
+        self.assertEquals(num_seqs, 4)
+
+        for label in id_to_count:
+            self.assertEquals(expected_derep[label], id_to_count[label])
+            
+    def test_vsearch_dereplicate_exact_seqs_empty_working_dir(self):
+        """ Test dereplicating sequences without passing
+            a working directory
+        """
+        tmp_fp = join(self.output_dir, "tmp_derep_reads.fasta")
+
+        dereplicated_seqs_fp, uc_fp = vsearch_dereplicate_exact_seqs(
+            self.seqs_to_derep_fp,
+            tmp_fp,
+            output_uc=True,
+            working_dir=None,
+            strand="both",
+            maxuniquesize=None,
+            minuniquesize=None,
+            sizein=False,
+            sizeout=True)
+
+        # check dereplicated seqs and uc file in the same
+        # directory (same path as tmp_fp)
+        self.assertEquals(dirname(tmp_fp), dirname(dereplicated_seqs_fp))
+        self.assertEquals(dirname(tmp_fp), dirname(uc_fp))
+
+    def test_vsearch_dereplicate_exact_seqs_abundance(self):
+        """ Test dereplicating sequences and discarding those with
+            abundance < 2 and abundance > 6
+        """
+        tmp_fp = join(self.output_dir, "tmp_derep_reads.fasta")
+
+        dereplicated_seqs_fp, uc_fp = vsearch_dereplicate_exact_seqs(
+            self.seqs_to_derep_max_min_abundance_fp,
+            tmp_fp,
+            output_uc=False,
+            working_dir=self.output_dir,
+            strand="both",
+            maxuniquesize=6,
+            minuniquesize=2,
+            sizein=False,
+            sizeout=True)
+
+        # no output for .uc
+        self.assertTrue(uc_fp is None)
+
+        num_seqs = 0
+        expected_derep = ['HWI-ST157_0368:1:1106:10560:153880#0/1;size=6;',
+                          'HWI-ST157_0368:1:2103:12440:90119#0/1;size=2;',
+                          'HWI-ST157_0368:1:1106:15269:103850#0/1;size=3;',
+                          'HWI-ST157_0368:1:1205:9745:86166#0/1;size=5;']
+
+        with open(tmp_fp, "U") as tmp_f:
+            for label, seq in parse_fasta(tmp_f):
+                num_seqs += 1
+                # check output labels are correct
+                self.assertTrue(label in expected_derep)
+                # check sequence exists
+                self.assertTrue(len(seq) > 0)
+
+        # check there are 4 sequences after dereplication
+        self.assertEquals(num_seqs, 4)
+
+    def test_vsearch_dereplicate_exact_seqs_merged(self):
+        """ Test dereplicating sequences which already contain
+            abundance information in the label from previous
+            dereplication (ex. two dereplicated files have been
+            merged into a new file for dereplication)
+        """
+        tmp_fp = join(self.output_dir, "tmp_derep_reads.fasta")
+
+        dereplicated_seqs_fp, uc_fp = vsearch_dereplicate_exact_seqs(
+            self.seqs_to_derep_merged_derep_files_fp,
+            tmp_fp,
+            output_uc=False,
+            working_dir=self.output_dir,
+            strand="both",
+            maxuniquesize=None,
+            minuniquesize=None,
+            sizein=True,
+            sizeout=True)
+
+        # no output for .uc
+        self.assertTrue(uc_fp is None)
+
+        num_seqs = 0
+        expected_derep = ['HWI-ST157_0368:1:1207:16180:126921#0/1;size=6;',
+                          'HWI-ST157_0368:1:2103:7895:197066#0/1;size=6;',
+                          'HWI-ST157_0368:1:1106:11378:83198#0/1;size=2;',
+                          'HWI-ST157_0368:1:2102:15078:69955#0/1;size=2;']
+
+        with open(tmp_fp, "U") as tmp_f:
+            for label, seq in parse_fasta(tmp_f):
+                num_seqs += 1
+                # check output labels are correct
+                self.assertTrue(label in expected_derep)
+                # check sequence exists
+                self.assertTrue(len(seq) > 0)
+
+        # check there are 4 sequences after dereplication
+        self.assertEquals(num_seqs, 4)
+
+    def test_vsearch_dereplicate_exact_seqs_strand(self):
+        """ Raise error when strand parameter is something
+            other than 'plus' or 'both'
+        """
+        tmp_fp = join(self.output_dir, "tmp_derep_reads.fasta")
+
+        self.assertRaises(ValueError,
+                          vsearch_dereplicate_exact_seqs,
+                          fasta_filepath=self.seqs_to_derep_fp,
+                          output_filepath=tmp_fp,
+                          output_uc=False,
+                          working_dir=None,
+                          strand="minus",
+                          maxuniquesize=None,
+                          minuniquesize=None,
+                          sizein=False,
+                          sizeout=True,
+                          log_name="derep.log",
+                          HALT_EXEC=False)
+
+
+# Test dereplicating sequences using default parameters
+seqs_to_derep=""">HWI-ST157_0368:1:2102:15078:69955#0/1
+TACGTAGGGCCCGAGCGTTGTCCGGATTTATTGGGCGTAAAGCGTGCGCAGGCGGTCTGTTAAGTCTGTAGTTAAAGGCTGTGGCTCAACTATGGTTAGTT
+>HWI-ST157_0368:1:2103:7895:197066#0/1
+TACGTAGGGGGCAAGCGTTGTCCGAATTTACTGGGTGTAAAGGGAGCGCAGACGGCACGGCAAGCCAGATGTGAAAGCCCGGGGCTCAACCCCGGGACTGC
+>HWI-ST157_0368:1:1207:16180:126921#0/1
+TACGTAGGTCCCGAGCGTTGTCCGGATTTATTGGGCGTAAAGCGAGCGCAGGCGGATACTTAAGTCTGGTGTGAAAACCTAGGGCTCAACCCTGGGACTGC
+>HWI-ST157_0368:1:1106:11378:83198#0/1
+TACGTAGGGAGCAAGCGTTGTCCGGATTTACTGGGTGTAAAGGGTGCGTAGGCGGCTTTGCAAGTCAGATGTGAAATCTATGGGCTCAACCCATAAACTGC
+>HWI-ST157_0368:1:2103:7895:197066#0/2
+TACGTAGGGGGCAAGCGTTGTCCGAATTTACTGGGTGTAAAGGGAGCGCAGACGGCACGGCAAGCCAGATGTGAAAGCCCGGGGCTCAACCCCGGGACTGC
+>HWI-ST157_0368:1:2103:7895:197066#0/3
+TACGTAGGGGGCAAGCGTTGTCCGAATTTACTGGGTGTAAAGGGAGCGCAGACGGCACGGCAAGCCAGATGTGAAAGCCCGGGGCTCAACCCCGGGACTGC
+>HWI-ST157_0368:1:1207:16180:126921#0/2
+TACGTAGGTCCCGAGCGTTGTCCGGATTTATTGGGCGTAAAGCGAGCGCAGGCGGATACTTAAGTCTGGTGTGAAAACCTAGGGCTCAACCCTGGGACTGC
+>HWI-ST157_0368:1:1207:16180:126921#0/3
+TACGTAGGTCCCGAGCGTTGTCCGGATTTATTGGGCGTAAAGCGAGCGCAGGCGGATACTTAAGTCTGGTGTGAAAACCTAGGGCTCAACCCTGGGACTGC
+"""
+
+# Test dereplicating a file which is a concatenation of two separately
+# dereplicated files. The input fasta file contains abundance information.
+seqs_to_derep_merged_derep_files = """>HWI-ST157_0368:1:2102:15078:69955#0/1;size=1;
+TACGTAGGGCCCGAGCGTTGTCCGGATTTATTGGGCGTAAAGCGTGCGCAGGCGGTCTGTTAAGTCTGTAGTTAAAGGCTGTGGCTCAACTATGGTTAGTT
+>HWI-ST157_0368:1:2103:7895:197066#0/1;size=3;
+TACGTAGGGGGCAAGCGTTGTCCGAATTTACTGGGTGTAAAGGGAGCGCAGACGGCACGGCAAGCCAGATGTGAAAGCCCGGGGCTCAACCCCGGGACTGC
+>HWI-ST157_0368:1:1207:16180:126921#0/1;size=3;
+TACGTAGGTCCCGAGCGTTGTCCGGATTTATTGGGCGTAAAGCGAGCGCAGGCGGATACTTAAGTCTGGTGTGAAAACCTAGGGCTCAACCCTGGGACTGC
+>HWI-ST157_0368:1:1106:11378:83198#0/1;size=1;
+TACGTAGGGAGCAAGCGTTGTCCGGATTTACTGGGTGTAAAGGGTGCGTAGGCGGCTTTGCAAGTCAGATGTGAAATCTATGGGCTCAACCCATAAACTGC
+>HWI-ST157_0368:1:2102:15078:69955#1/1;size=1;                                                    
+TACGTAGGGCCCGAGCGTTGTCCGGATTTATTGGGCGTAAAGCGTGCGCAGGCGGTCTGTTAAGTCTGTAGTTAAAGGCTGTGGCTCAACTATGGTTAGTT
+>HWI-ST157_0368:1:2103:7895:197066#1/1;size=3;
+TACGTAGGGGGCAAGCGTTGTCCGAATTTACTGGGTGTAAAGGGAGCGCAGACGGCACGGCAAGCCAGATGTGAAAGCCCGGGGCTCAACCCCGGGACTGC
+>HWI-ST157_0368:1:1207:16180:126921#1/1;size=3;
+TACGTAGGTCCCGAGCGTTGTCCGGATTTATTGGGCGTAAAGCGAGCGCAGGCGGATACTTAAGTCTGGTGTGAAAACCTAGGGCTCAACCCTGGGACTGC
+>HWI-ST157_0368:1:1106:11378:83198#1/1;size=1;
+TACGTAGGGAGCAAGCGTTGTCCGGATTTACTGGGTGTAAAGGGTGCGTAGGCGGCTTTGCAAGTCAGATGTGAAATCTATGGGCTCAACCCATAAACTGC
+"""
+
+# Sequences to dereplicate with final clusters as follows:
+# 2 clusters with abundance 6 and 7
+# 3 clusters with abundance 1
+# 3 clusters with abundance 2, 3, 5
+seqs_to_derep_max_min_abundance = """>HWI-ST157_0368:1:1106:10560:153880#0/1
+TACGTAGGTGGCGAGCGTTATCCGGATTTACTGGGTGTAAAGGGCGCGTAGGCGGGAATGCAAGTCAGATGTGAAATCCAGGGGCTTAACCCTTGAACTGC
+>HWI-ST157_0368:1:1106:10560:153880#0/2
+TACGTAGGTGGCGAGCGTTATCCGGATTTACTGGGTGTAAAGGGCGCGTAGGCGGGAATGCAAGTCAGATGTGAAATCCAGGGGCTTAACCCTTGAACTGC
+>HWI-ST157_0368:1:1106:10560:153880#0/3
+TACGTAGGTGGCGAGCGTTATCCGGATTTACTGGGTGTAAAGGGCGCGTAGGCGGGAATGCAAGTCAGATGTGAAATCCAGGGGCTTAACCCTTGAACTGC
+>HWI-ST157_0368:1:1106:10560:153880#0/4
+TACGTAGGTGGCGAGCGTTATCCGGATTTACTGGGTGTAAAGGGCGCGTAGGCGGGAATGCAAGTCAGATGTGAAATCCAGGGGCTTAACCCTTGAACTGC
+>HWI-ST157_0368:1:1106:10560:153880#0/5
+TACGTAGGTGGCGAGCGTTATCCGGATTTACTGGGTGTAAAGGGCGCGTAGGCGGGAATGCAAGTCAGATGTGAAATCCAGGGGCTTAACCCTTGAACTGC
+>HWI-ST157_0368:1:1106:10560:153880#0/6
+TACGTAGGTGGCGAGCGTTATCCGGATTTACTGGGTGTAAAGGGCGCGTAGGCGGGAATGCAAGTCAGATGTGAAATCCAGGGGCTTAACCCTTGAACTGC
+>HWI-ST157_0368:1:2104:14337:180515#0/1
+TACGGAGGGTGCAAGCGTTAATCGGAATTACTGGGCGTAAAGGGCGCGCAGGCGGTCTGGCAAGTCGGATGTGAAATCCCCGGGCTCAACCTGGGAACTGC
+>HWI-ST157_0368:1:2104:14337:180515#0/2
+TACGGAGGGTGCAAGCGTTAATCGGAATTACTGGGCGTAAAGGGCGCGCAGGCGGTCTGGCAAGTCGGATGTGAAATCCCCGGGCTCAACCTGGGAACTGC
+>HWI-ST157_0368:1:2104:14337:180515#0/3
+TACGGAGGGTGCAAGCGTTAATCGGAATTACTGGGCGTAAAGGGCGCGCAGGCGGTCTGGCAAGTCGGATGTGAAATCCCCGGGCTCAACCTGGGAACTGC
+>HWI-ST157_0368:1:2104:14337:180515#0/4
+TACGGAGGGTGCAAGCGTTAATCGGAATTACTGGGCGTAAAGGGCGCGCAGGCGGTCTGGCAAGTCGGATGTGAAATCCCCGGGCTCAACCTGGGAACTGC
+>HWI-ST157_0368:1:2104:14337:180515#0/5
+TACGGAGGGTGCAAGCGTTAATCGGAATTACTGGGCGTAAAGGGCGCGCAGGCGGTCTGGCAAGTCGGATGTGAAATCCCCGGGCTCAACCTGGGAACTGC
+>HWI-ST157_0368:1:2104:14337:180515#0/6
+TACGGAGGGTGCAAGCGTTAATCGGAATTACTGGGCGTAAAGGGCGCGCAGGCGGTCTGGCAAGTCGGATGTGAAATCCCCGGGCTCAACCTGGGAACTGC
+>HWI-ST157_0368:1:2104:14337:180515#0/7
+TACGGAGGGTGCAAGCGTTAATCGGAATTACTGGGCGTAAAGGGCGCGCAGGCGGTCTGGCAAGTCGGATGTGAAATCCCCGGGCTCAACCTGGGAACTGC
+>HWI-ST157_0368:1:1102:8490:14349#0/1
+AACGTAGGTCACAAGCGTTGTCCGGAATTACTGGGTGTAAAGGGAGCGCAGGCGGGAAGACAAGTTGGAAGTGAAATCTATGGGCTCAACCCATAAACTGC
+>HWI-ST157_0368:1:1205:18016:113727#0/1
+TACGGAGGGTGCAAGCGTTAATCGGAATTACTGGGCGTAAAGCGCACGCAGGCGGTTGATTAAGTTAGATGTGAAATCCCCGGGCTTAACCTGGGGATGGC
+>HWI-ST157_0368:1:1201:16382:127646#0/1
+TACAGAGGTCTCAAGCGTTGTTCGGAATCACTGGGCGTAAAGCGTGCGTAGGCGGTTTCGTAAGTCGGGTGTGAAAGGCGGGGGCTTAACGCCCGGACTGG
+>HWI-ST157_0368:1:2103:12440:90119#0/1
+TACGGAGGATGCGAGCGTTATCCGGATTTATTGGGTTTAAAGGGTGCGTAGGCGGCACGCCAAGTCAGCGGTGAAATTTCCGGGCTCAACCCGGAGTGTGC
+>HWI-ST157_0368:1:2103:12440:90119#0/2
+TACGGAGGATGCGAGCGTTATCCGGATTTATTGGGTTTAAAGGGTGCGTAGGCGGCACGCCAAGTCAGCGGTGAAATTTCCGGGCTCAACCCGGAGTGTGC
+>HWI-ST157_0368:1:1106:15269:103850#0/1
+TACGGAGGATCCGAGCGTTATCCGGATTTATTGGGTTTAAAGGGAGCGTAGATGGGTTGTTAAGTCAGTTGTGAAAGTTTGCGGCTCAACCGTAAAATTGC
+>HWI-ST157_0368:1:1106:15269:103850#0/2
+TACGGAGGATCCGAGCGTTATCCGGATTTATTGGGTTTAAAGGGAGCGTAGATGGGTTGTTAAGTCAGTTGTGAAAGTTTGCGGCTCAACCGTAAAATTGC
+>HWI-ST157_0368:1:1106:15269:103850#0/3
+TACGGAGGATCCGAGCGTTATCCGGATTTATTGGGTTTAAAGGGAGCGTAGATGGGTTGTTAAGTCAGTTGTGAAAGTTTGCGGCTCAACCGTAAAATTGC
+>HWI-ST157_0368:1:1205:9745:86166#0/1
+TACGTAGGTCCCGAGCGTTATCCGGATTTACTGGGCGTAAAGGGAGCGTAGGCGGATGATTAAGTGGGATGTGAAATACCCGGGCTCAACTTGGGTGCTGC
+>HWI-ST157_0368:1:1205:9745:86166#0/2
+TACGTAGGTCCCGAGCGTTATCCGGATTTACTGGGCGTAAAGGGAGCGTAGGCGGATGATTAAGTGGGATGTGAAATACCCGGGCTCAACTTGGGTGCTGC
+>HWI-ST157_0368:1:1205:9745:86166#0/3
+TACGTAGGTCCCGAGCGTTATCCGGATTTACTGGGCGTAAAGGGAGCGTAGGCGGATGATTAAGTGGGATGTGAAATACCCGGGCTCAACTTGGGTGCTGC
+>HWI-ST157_0368:1:1205:9745:86166#0/4
+TACGTAGGTCCCGAGCGTTATCCGGATTTACTGGGCGTAAAGGGAGCGTAGGCGGATGATTAAGTGGGATGTGAAATACCCGGGCTCAACTTGGGTGCTGC
+>HWI-ST157_0368:1:1205:9745:86166#0/5
+TACGTAGGTCCCGAGCGTTATCCGGATTTACTGGGCGTAAAGGGAGCGTAGGCGGATGATTAAGTGGGATGTGAAATACCCGGGCTCAACTTGGGTGCTGC
+"""
+
+# Test sort by abundance functionality in VSEARCH
+seqs_to_sort=""">HWI-ST157_0368:1:2105:3428:36721#0/1;size=5;
+TACGTAGGGTGCAAGCGTTATCCGGAATTATTGGGCGTAAAGGGCTCGTAGGCGGTTCGTCGCGTCCGGTGTGAAAGTCCATCGCTTAACGGTGGATCTGC
+>HWI-ST157_0368:1:2106:18272:88408#0/1;size=2;
+TACGTAGGGGGCAAGCGTTATCCGGATTTACTGGGTGTAAAGGGAGCGTAGACGGCGGAGCAAGTCTGAAGTGAAAGCCCGGGGCTCAACCCCGGGACTGC
+>HWI-ST157_0368:1:1106:12200:200135#0/1;size=1;
+TACGTAGGTGGCGAGCGTTATCCGGAATTATTGGGCGTAAAGAGGGAGCAGGCGGCACTAAGGGTCTGTGGTGAAAGATCGAAGCTTAACTTCGGTAAGCC
+>HWI-ST157_0368:1:1201:8401:113582#0/1;size=10;
+TACGTAGGGGGCAAGCGTTATCCGGATTTACTGGGTGTAAAGGGAGCGTAGACGGTGTGGCAAGTCTGATGTGAAAGGCATGGGCTTAACCTGTGGACTGC
+>HWI-ST157_0368:1:2208:9135:145970#0/1;size=1;
+TACGTAGGGGGCGAGCGTTGTCCGGAATTACTGGGCGTAAGGGGAGCGTAGGCGGTCGATTAAGTTAGATGTGAAACCCCCGGGCTTAACTTGGGGACTGC
+>HWI-ST157_0368:1:2204:20491:181552#0/1;size=10;
+TACGTAGGGTGCAAGCGTTATCCGGAATTATTGGGCGTAAAGGGCTCGTAGGCGGTTCGTCGAGTCTGGTGTGAAAGTCCATCGCTTAACGGTGGATCCGC
+>HWI-ST157_0368:1:2105:6731:137157#0/1;size=4;
+TACGTAGGTCCCGAGCGTTGTCCGGATTTATTGGGCGTAAAGCGAGCGCAGGCGGTTTGATAAGTCTGAAGTTAAAGGCTGTGGCTCAACCATAGTTCGCT
+>HWI-ST157_0368:1:2107:19923:3944#0/1;size=100;
+TGCATTTTCTCTTATCGAAAACCTTCAGCGTTCTGATCTGAATCCCGTCGAAGAGGCTAAGGGCTATCGCCAACTCATTGATGCCAGCGGGATGACCCAGG
+"""
+
+# Grinder simulated chimeric reads using Greengenes 13.8 release
+# command used: grinder -random_seed 100 -reference_file 97_otus_gg_13_8.fasta \
+#                       -forward_reverse ./primers.fna -length_bias 0 -copy_bias 1 \
+#                       -unidirectional 1 -read_dist 150 -mutation_dist uniform 0.1 \
+#                       -mutation_ratio 100 0 -total_reads 1000 -diversity 10 -chimera_perc 10 \
+#                       -od grinder_chimeric_reads_illumina
+# primers.fna contain 515f and 806r primers
+# reads >251 reference=4370324,646991 amplicon=488..779,499..789 position=1..150
+#       >320 reference=646991,4370324,646991 amplicon=499..789,488..779,499..789 position=1..150
+#       >36 reference=4370324,814974 amplicon=488..779,479..769 position=1..150
+#       >672 reference=814974,160832 amplicon=479..769,436..727 position=1..150
+#       >142 reference=160832,814974 amplicon=436..727,479..769 position=1..150 errors=2%G
+#       >201 reference=4304512,510574 amplicon=451..742,501..793 position=1..150
+#       >241 reference=646991,4370324 amplicon=499..789,488..779 position=1..150 errors=13%A
+#       >279 reference=311922,160832,510574 amplicon=481..773,436..727,501..793 position=1..150
+#       >299 reference=4370324,4304512 amplicon=488..779,451..742 position=1..150
+#       >359 reference=646991,4370324 amplicon=499..789,488..779 position=1..150 errors=52%A
+#       >375 reference=4304512,769294 amplicon=451..742,504..795 position=1..150
+#       >407 reference=4304512,579954 amplicon=451..742,488..779 position=1..150
+#       >423 reference=4370324,579954 amplicon=488..779,488..779 position=1..150
+#       >516 reference=814974,579954 amplicon=479..769,488..779 position=1..150
+#       >618 reference=814974,646991 amplicon=479..769,499..789 position=1..150 errors=32%C
+#       >717 reference=814974,510574 amplicon=479..769,501..793 position=1..150
+#       >902 reference=510574,579954 amplicon=501..793,488..779 position=1..150
+#       >918 reference=814974,4370324 amplicon=479..769,488..779 position=1..150
+#       >941 reference=579954,4304512 amplicon=488..779,451..742 position=1..150
+#       are chimeric
+amplicon_reads=""">3;size=102;
+GTGCCAGCAGCCGCGGTAATACATAGGTCACAAGCGTTATCCGGATTTATTGGGCGTAAAGCGTTCGTAGGCGGTTTGTT
+AAGTCTAGAGTTAAAGCCTGGGGTTCAACCCCAGCCCGCTTTGGATACTGACAAACTAGAGTTACATAGA
+>16;size=95;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTAATCGGAATTACTGGGCGTAAAGCGCACGCAGGCGGTTAATT
+AAGCTAGAAGTGAAAGCCCTGCGCTCAACGTGGGAAGGCCTTTTAGAACTGGTTAACTAGAGTATTGGAG
+>22;size=93;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTGTCCGGATTTATTGGGTTTAAAGGGTACGTAGGCGGTGTATT
+AAGTCAGTGGTGAAAGCCTGCGGCTCAACCGTAGGAGTGCCATTGATACTGGTATACTTGAGTGTTGTAA
+>2;size=87;
+GTGCCAGCAGCCGCGGTAATACGTAGGGCGCAAGCGTTATCCGGAATTATTGGGCGTAAAGAGCTCGTAGGCGGTTTGTC
+GCGTCTGCCGTGAAAGTCCGGGGCTTAACTCCGGATCTGCGGTGGGTACGGGCAGACTTGAGTGATGTAG
+>39;size=84;
+GTGCCAGCAGCCGCGGTAATACGTAGGGGGCAAGCGTTGTCCGGATTTACTGGGTATAAAGGGCTCGCAGGCGGGTTTGT
+AAGTCAGAGGTGAAATCCTACAGCTTAACTGTAGAACTGCCTTTGAAACTGCAAGTCTTGAGATCGGAAG
+>4;size=79;
+GTGCCAGCAGCCGCGGTAATACGTAGGGTGCGAGCGTTAATCGGAATTACTGGGCGTAAAGCGTGCGCAGGCGGCTACAT
+AAGACAGGTGTGAAATCCCCGGGCTCAACCTGGGAATGGCGCTTGTGACTGTGTGGCTTGAGTTCGGCAG
+>6;size=72;
+GTGCCAGCAGCCGCGGTAATACGAAGGGGGCTAGCGTTGCTCGGAATTACTGGGCGTAAAGGGAGCGTAGGCGGACATTT
+AAGTCAGGGGTGAAATCCCAGAGCTCAACTCTGGAACTGCCTTTGATACTGGATGTCTTGAGTGTGAGAG
+>11;size=70;
+GTGCCAGCAGCCGCGGTAATACAGAGGTCTCAAGCGTTGTTCGGATTCATTGGGCGTAAAGGGTGCGTAGGTGGCGGGGT
+AAGTCAGGTGTGAAATCTCGGAGCTCAACTCCGAAACTGCACTTGATACTGCCTTGCTCGAGTACTGGAG
+>45;size=67;
+GTGCCAGCAGCCGCGGTAATACGGAGGATGCGAGCGTTATCCGGATTTATTGGGTTTAAAGGGTGCGTAGGCGGAATGGT
+AAGTCAGTGGTGAAATCCTGCAGCTCAACTGTAGAGTTGCCATTGATACTGTCATTCTTGAGTATAGATG
+>1;size=65;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTAATCGGAATTACTGGGCGTAAAGCGCATGCAGGCGGTTTGTT
+AAGTCAGATGTGAAAGCCCGGGGCTCAACCTCGGAACCGCATTTGAAACTGGCAGGCTAGAGTCTTGTAG
+>251;size=2;
+GTGCCAGCAGCCGCGGTAATACGGAGGATGCGAGCGTTATCCGGATTTATTGGGTTTAAAGGGTGCGTAGGCGGAATGGT
+AAGTCAGTGGTGAAATCCTGCAGCTCAACTGTAGAGTTGCCATTGATACTGGTATACTTGAGTGTTGTAA
+>30;size=2;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTGTCCGGATTTATTGGGTTTAAAGGGTGCGTAGGCGGAATGGT
+AAGTCAGTGGTGAAATCCTGCAGCTCAACTGTAGAGTTGCCATTGATACTGTCATTCTTGAGTATAGATG
+>320;size=2;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTGTCCGGATTTATTGGGTTTAAAGGGTACGTAGGCGGTGTATT
+AAGTCAGTGGTGAAATCCTGCAGCTCAACTGTAGAGTTGCCATTGATACTGTCATTCTTGAGTATAGATG
+>36;size=2;
+GTGCCAGCAGCCGCGGTAATACGGAGGATGCGAGCGTTATCCGGATTTATTGGGCGTAAAGCGTTCGTAGGCGGTTTGTT
+AAGTCTAGAGTTAAAGCCTGGGGTTCAACCCCAGCCCGCTTTGGATACTGACAAACTAGAGTTACATAGA
+>425;size=2;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTAATCGGAATTACTGGGCGTAAAGCGTGCGCAGGCGGCTACAT
+AAGACAGGTGTGAAATCCCCGGGCTCAACCTGGGAATGGCGCTTGTGACTGTGTGGCTTGAGTTCGGCAG
+>672;size=2;
+GTGCCAGCAGCCGCGGTAATACATAGGTCACAAGCGTTATCCGGATTTATTGGGCGTAAAGCGTTCGTAGGCGGTTTGTT
+AAGTCAGATGTGAAAGCCCGGGGCTCAACCTCGGAACCGCATTTGAAACTGGCAGGCTAGAGTCTTGTAG
+>10;size=1;
+GTGCCAGCAGCCGCGGTAATACGTAGGGCGCAAGCGTTATCCGGAATTATTGGGCGTAAAGAGCTCGTAGGCGGTTTGTC
+GGGTCTGCCGTGAAAGTCCGGGGCTTAACTCCGGATCTGCGGTGGGTACGGGCAGACTTGAGTGATGTAG
+>100;size=1;
+TTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTGTCCGGATTTATTGGGTTTAAAGGGTACGTAGGCGGTGTATT
+AAGTCAGTGGTGAAAGCCTGCGGCTCAACCGTAGGAGTGCCATTGATACTGGTATACTTGAGTGTTGTAA
+>102;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTGTCCGGACTTATTGGGTTTAAAGGGTACGTAGGCGGTGTATT
+AAGTCAGTGGTGAAAGCCTGCGGCTCAACCGTAGGAGTGCCATTGATACTGGTATACTTGAGTGTTGTAA
+>115;size=1;
+GTGCCAGCAGCCGCGGTATTACATAGGTCACAAGCGTTATCCGGATTTATTGGGCGTAAAGCGTTCGTAGGCGGTTTGTT
+AAGTCTAGAGTTAAAGCCTGGGGTTCAACCCCAGCCCGCTTTGGATACTGACAAACTAGAGTTACATAGA
+>123;size=1;
+GTGACAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTAATCGGAATTACTGGGCGTAAAGCGCATGCAGGCGGTTTGTT
+AAGTCAGATGTGAAAGCCCGGGGCTCAACCTCGGAACCGCATTTGAAACTGGCAGGCTAGAGTCTTGTAG
+>132;size=1;
+GTGCCAGCAGCCGCGGTAATACGTAGGGGGCAAGCGTTGTCCGGATTTACTGGGTATAAAGGGCTCGCAGGCGGGTTTGT
+AAGTCAGAGGTGAAATCCTACAGCTTAACTGTAGAACTGCCTTTGACACTGCAAGTCTTGAGATCGGAAG
+>134;size=1;
+GTGCCGGCAGCCGCGGTAATACGTAGGGTGCGAGCGTTAATCGGAATTACTGGGCGTAAAGCGTGCGCAGGCGGCTACAT
+AAGACAGGTGTGAAATCCCCGGGCTCAACCTGGGAATGGCGCTTGTGACTGTGTGGCTTGAGTTCGGCAG
+>14;size=1;
+GTGCCAGCAGCCGCGGTAATACAGAGGTCTCACGCGTTGTTCGGATTCATTGGGCGTAAAGGGTGCGTAGGTGGCGGGGT
+AAGTCAGGTGTGAAATCTCGGAGCTCAACTCCGAAACTGCACTTGATACTGCCTTGCTCGAGTACTGGAG
+>140;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTAATCGGAATTACTGGGCGGAAAGCGCATGCAGGCGGTTTGTT
+AAGTCAGATGTGAAAGCCCGGGGCTCAACCTCGGAACCGCATTTGAAACTGGCAGGCTAGAGTCTTGTAG
+>142;size=1;
+GGGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTAATCGGAATTACTGGGCGTAAAGCGCATGCAGGCGGTTTGTT
+AAGTCTAGAGTTAAAGCCTGGGGTTCAACCCCAGCCCGCTTTGGATACTGACAAACTAGAGTTACATAGA
+>144;size=1;
+GTGTCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTAATCGGAATTACTGGGCGTAAAGCGCATGCAGGCGGTTTGTT
+AAGTCAGATGTGAAAGCCCGGGGCTCAACCTCGGAACCGCATTTGAAACTGGCAGGCTAGAGTCTTGTAG
+>148;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGATGCGAGCGTTATCCGGATTTATTGGGTTTAAAGGGTGCGTAGGCGGAATGGT
+AAGTCAGTGGTGAAATCCTGCAGCTCAACTGTAGAGTTGCCATTGATACTATCATTCTTGAGTATAGATG
+>15;size=1;
+GTGCCAGCAGCCGCGGTAATACATAGGTCACAAGCGTTATCCGGATTTATTGGGAGTAAAGCGTTCGTAGGCGGTTTGTT
+AAGTCTAGAGTTAAAGCCTGGGGTTCAACCCCAGCCCGCTTTGGATACTGACAAACTAGAGTTACATAGA
+>156;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTAATCGGAATTACTGGGCGTAAAGCGCACGCAGACGGTTAATT
+AAGCTAGAAGTGAAAGCCCTGCGCTCAACGTGGGAAGGCCTTTTAGAACTGGTTAACTAGAGTATTGGAG
+>161;size=1;
+GTGCCAGCAGCCGCGGTAATACAGAGGTCTCAAGCGTTGTTCGGATTCATTGGGCGTAAAGGGTGCGTAGGTGGCGGGGT
+AAGTCAGGGGTGAAATCTCGGAGCTCAACTCCGAAACTGCACTTGATACTGCCTTGCTCGAGTACTGGAG
+>162;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGCTAATCGGAATTACTGGGCGTAAAGCGCACGCAGGCGGTTAATT
+AAGCTAGAAGTGAAAGCCCTGCGCTCAACGTGGGAAGGCCTTTTAGAACTGGTTAACTAGAGTATTGGAG
+>186;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTGTCCGGATTAATTGGGTTTAAAGGGTACGTAGGCGGTGTATT
+AAGTCAGTGGTGAAAGCCTGCGGCTCAACCGTAGGAGTGCCATTGATACTGGTATACTTGAGTGTTGTAA
+>201;size=1;
+GTGCCAGCAGCCGCGGTAATACGAAGGGGGCTAGCGTTGCTCGGAATTACTGGGCGTAAAGCGTGCGCAGGCGGCTACAT
+AAGACAGGTGTGAAATCCCCGGGCTCAACCTGGGAATGGCGCTTGTGACTGTGTGGCTTGAGTTCGGCAG
+>203;size=1;
+GTGCCAGCAGCCGCGGTAATACGTAGGGTGCGAGCGTTAATCGGAATTACTGGGCGTAAAGCGTGCGCAGGCGGCTACAT
+AAGACAGGTGTGAAATCCCCGGGCTCAACCTGGGAACGGCGCTTGTGACTGTGTGGCTTGAGTTCGGCAG
+>21;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTAATCGGAATTACTGGGCGTCAAGCGCATGCAGGCGGTTTGTT
+AAGTCAGATGTGAAAGCCCGGGGCTCAACCTCGGAACCGCATTTGAAACTGGCAGGCTAGAGTCTTGTAG
+>217;size=1;
+GTGCCAGCAGCCGCGGTAATACGAAGGGGGCTAGCGTTGCTCGGAATTACTGGGCGTAAAGGGAGCGTAGGCGGACATTT
+AAGTCAGGGGTGTAATCCCAGAGCTCAACTCTGGAACTGCCTTTGATACTGGATGTCTTGAGTGTGAGAG
+>218;size=1;
+GTGCCAGCAGCCGCGGTAATACGTAGGGTGCGAGCGTTAATCGGAATTACTGGGCGTAACGCGTGCGCAGGCGGCTACAT
+AAGACAGGTGTGAAATCCCCGGGCTCAACCTGGGAATGGCGCTTGTGACTGTGTGGCTTGAGTTCGGCAG
+>221;size=1;
+GTGCCAGCAGCCGCGGTAATACAGAGGTCTCAAGCGTTGTTCGGATTCATTGGGCGTAAAGGGTGCGTAGGTGGCGGGGT
+AAGTCAGGTGTGAAATCTCGGAGCTCAACTCCGAAACTGCACTTGATACTGCCTTGCTCGAATACTGGAG
+>222;size=1;
+GTGCCAGCAGCCGCGGTAATACGAAGGGGGCTAGGGTTGCTCGGAATTACTGGGCGTAAAGGGAGCGTAGGCGGACATTT
+AAGTCAGGGGTGAAATCCCAGAGCTCAACTCTGGAACTGCCTTTGATACTGGATGTCTTGAGTGTGAGAG
+>225;size=1;
+GTGCCAGCAGCCGCGGTAATACGAAGGGGGCTAGCGTTGCTCGGAATTACTGGGAGTAAAGGGAGCGTAGGCGGACATTT
+AAGTCAGGGGTGAAATCCCAGAGCTCAACTCTGGAACTGCCTTTGATACTGGATGTCTTGAGTGTGAGAG
+>233;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTGTCCGGATTTATTGGGTTTAAAGGGTACGTAGGCGGTGTATT
+AAGTCAGTGGTGAAAGCCTGCGGCTCAACCGTAGGAGTGCCATTGATACTGGTGTACTTGAGTGTTGTAA
+>234;size=1;
+GTGCCAGCAGCCTCGGTAATACGGAGGATGCGAGCGTTATCCGGATTTATTGGGTTTAAAGGGTGCGTAGGCGGAATGGT
+AAGTCAGTGGTGAAATCCTGCAGCTCAACTGTAGAGTTGCCATTGATACTGTCATTCTTGAGTATAGATG
+>235;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAACGTTAATCGGAATTACTGGGCGTAAAGCGCATGCAGGCGGTTTGTT
+AAGTCAGATGTGAAAGCCCGGGGCTCAACCTCGGAACCGCATTTGAAACTGGCAGGCTAGAGTCTTGTAG
+>24;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTAATCGGAAGTACTGGGCGTAAAGCGCACGCAGGCGGTTAATT
+AAGCTAGAAGTGAAAGCCCTGCGCTCAACGTGGGAAGGCCTTTTAGAACTGGTTAACTAGAGTATTGGAG
+>241;size=1;
+GTGCCAGCAGCCACGGTAATACGGAGGGTGCGAGCGTTGTCCGGATTTATTGGGTTTAAAGGGTACGTAGGCGGTGTATT
+AAGTCAGTGGTGAAAGCCTGCGGCTCAACCGTAGGAGTGCCATTGATACTGTCATTCTTGAGTATAGATG
+>249;size=1;
+GTGCCAGCAGCCGCGGTAATACGTAGGGGGCAAGCGTTGTCCGGATTTACTGGGTATAAAGGGCTCGCAGGCGGGTTTGT
+AAGTCAGAGGTGAAATCCTACAGCTTAACTGTAGAACTGCCTTTCAAACTGCAAGTCTTGAGATCGGAAG
+>259;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTAATCGGAATTACTGGGCGTAAAGCGCATGCAGGCGGTTTGTT
+AAGTCAGATGTGAAAGCGCGGGGCTCAACCTCGGAACCGCATTTGAAACTGGCAGGCTAGAGTCTTGTAG
+>26;size=1;
+GTGCCAGCAGCCGCGGTAATACAGAGGTCTCAAGCGTTGTTCGGATTCATTGGGCGTAAAGGGTGCGTAGGTGGCGGGGT
+AAGTCAGGTGTGAAATCTCGGAGCTCAACTCCGAAACTGCACATGATACTGCCTTGCTCGAGTACTGGAG
+>266;size=1;
+GTGCCAGCGGCCGCGGTAATACGTAGGGCGCAAGCGTTATCCGGAATTATTGGGCGTAAAGAGCTCGTAGGCGGTTTGTC
+GCGTCTGCCGTGAAAGTCCGGGGCTTAACTCCGGATCTGCGGTGGGTACGGGCAGACTTGAGTGATGTAG
+>27;size=1;
+GTGCCAGCAGCCGCGGTAATACATAGGTCACAAGCGTTATCCGGATTTATTGGGTGTAAAGCGTTCGTAGGCGGTTTGTT
+AAGTCTAGAGTTAAAGCCTGGGGTTCAACCCCAGCCCGCTTTGGATACTGACAAACTAGAGTTACATAGA
+>279;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTAATCGGAATTACTGGGCGTAAAGCGCATGCAGGCGGTTTGTT
+AAGTCAGATGTGAAAGCCCGGGGCTCAACCTGGGAATGGCGCTTGTGACTGTGTGGCTTGAGTTCGGCAG
+>296;size=1;
+GTGCCAGCAGCCGCGGTAATACGTAGGCGGCAAGCGTTGTCCGGATTTACTGGGTATAAAGGGCTCGCAGGCGGGTTTGT
+AAGTCAGAGGTGAAATCCTACAGCTTAACTGTAGAACTGCCTTTGAAACTGCAAGTCTTGAGATCGGAAG
+>299;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGATGCGAGCGTTATCCGGATTTATTGGGTTTAAAGGGTGCGTAGGCGGAATGGT
+AAGTCAGTGGTGAAATCCCAGAGCTCAACTCTGGAACTGCCTTTGATACTGGATGTCTTGAGTGTGAGAG
+>303;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGATGCGAGCGTTATCCGGATTTATTGGGTTTAAAGGGTGCGTAGGCGGAATGGT
+AAGTCAGTGGTGAAATCCAGCAGCTCAACTGTAGAGTTGCCATTGATACTGTCATTCTTGAGTATAGATG
+>306;size=1;
+GTGCCAGCAGCCGCGGTAATACGTAGGGGGCAAGCGTTGTCCGGATTTACTGGGTATAAAGGGCTCGCAGGCGGGTTTGT
+AAGTCAGAGGTGAAATCCTACAGCTTAACTGTAGAACTGCCTTTGAAACTGCAAGTCTTGAGATCGGAAA
+>307;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTGTCCGGATTTATTGGGTTTAAAGGGTACGTAGGCGGTGTATT
+AAGTCAGTGGTGAAAGCCTGCGGCTCAACCGTAGGAGTGCCATTGTTACTGGTATACTTGAGTGTTGTAA
+>32;size=1;
+GTGCCAGCAGCCGCGGTAATACGTAGGGCGCAAGCGGTATCCGGAATTATTGGGCGTAAAGAGCTCGTAGGCGGTTTGTC
+GCGTCTGCCGTGAAAGTCCGGGGCTTAACTCCGGATCTGCGGTGGGTACGGGCAGACTTGAGTGATGTAG
+>322;size=1;
+GTGCCAGCAGCCGCGGTAATACGTAGGGCGCAAGCGTTATCCGGAATTATTGGGCGTAAAGAGCTCGTAGGCGGTTTGTC
+GCGTCTGGCGTGAAAGTCCGGGGCTTAACTCCGGATCTGCGGTGGGTACGGGCAGACTTGAGTGATGTAG
+>326;size=1;
+GTGCCAGCAGCCGCGGTAATACGGTGGATGCGAGCGTTATCCGGATTTATTGGGTTTAAAGGGTGCGTAGGCGGAATGGT
+AAGTCAGTGGTGAAATCCTGCAGCTCAACTGTAGAGTTGCCATTGATACTGTCATTCTTGAGTATAGATG
+>332;size=1;
+GTGCCAGCAGCCGCGGTAATACGTAGGGCGCAAGCGTTATCCGGAATTATTGGGCGTAAAGAGCTCGTAGGCGGGTTGTC
+GCGTCTGCCGTGAAAGTCCGGGGCTTAACTCCGGATCTGCGGTGGGTACGGGCAGACTTGAGTGATGTAG
+>333;size=1;
+GTGCCAGCAGCCGCGGTAATACGTAGGGCGCAAGCGTTATCCGGAATTATTGGGCGTAAAGAGCTCGTATGCGGTTTGTC
+GCGTCTGCCGTGAAAGTCCGGGGCTTAACTCCGGATCTGCGGTGGGTACGGGCAGACTTGAGTGATGTAG
+>338;size=1;
+GTGCCAGCAGCCGCGGTATTACGGAGGGTGCGAGCGTTAATCGGAATTACTGGGCGTAAAGCGCATGCAGGCGGTTTGTT
+AAGTCAGATGTGAAAGCCCGGGGCTCAACCTCGGAACCGCATTTGAAACTGGCAGGCTAGAGTCTTGTAG
+>359;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTGTCCGGATTTATTAGGTTTAAAGGGTACGTAGGCGGTGTATT
+AAGTCAGTGGTGAAAGCCTGCGGCTCAACCGTAGGAGTGCCATTGATACTGTCATTCTTGAGTATAGATG
+>360;size=1;
+GTGCCAGCAGCCGCGGTAATACGTAGGGGGCAAGCGTTGTCCGGATTTACTGGGTATAAAGGGTTCGCAGGCGGGTTTGT
+AAGTCAGAGGTGAAATCCTACAGCTTAACTGTAGAACTGCCTTTGAAACTGCAAGTCTTGAGATCGGAAG
+>362;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTAATCGGAATTACTGGGCGTAAAGCGCATGCAGGCGGTTTGTT
+AAGTCAGATGTGAAAGCCCGGGGCTCAACCTCGGAACCGAATTTGAAACTGGCAGGCTAGAGTCTTGTAG
+>364;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTAATCGGAATTACTGGGCGTAAAGCGCACGCAGGCGGTTAATT
+AAGCTAGAAGTGAAAGCCCTGCGCTCAACGTGGGAAGGCCATTTAGAACTGGTTAACTAGAGTATTGGAG
+>366;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCCTTAATCGGAATTACTGGGCGTAAAGCGCATGCAGGCGGTTTGTT
+AAGTCAGATGTGAAAGCCCGGGGCTCAACCTCGGAACCGCATTTGAAACTGGCAGGCTAGAGTCTTGTAG
+>369;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTAATCGGAATTAATGGGCGTAAAGCGCATGCAGGCGGTTTGTT
+AAGTCAGATGTGAAAGCCCGGGGCTCAACCTCGGAACCGCATTTGAAACTGGCAGGCTAGAGTCTTGTAG
+>37;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTGTCCGGATTTATTGGGTTTAAAGGGTACTTAGGCGGTGTATT
+AAGTCAGTGGTGAAAGCCTGCGGCTCAACCGTAGGAGTGCCATTGATACTGGTATACTTGAGTGTTGTAA
+>371;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTAATCGGAATTACTGGGCGTAAAGCGCACGCAGGCGGTTAATT
+AAGCTAGAAGTGAAAGCCCTGCGCTCAACGCGGGAAGGCCTTTTAGAACTGGTTAACTAGAGTATTGGAG
+>373;size=1;
+GTGCCAGCAGACGCGGTAATACGTAGGGCGCAAGCGTTATCCGGAATTATTGGGCGTAAAGAGCTCGTAGGCGGTTTGTC
+GCGTCTGCCGTGAAAGTCCGGGGCTTAACTCCGGATCTGCGGTGGGTACGGGCAGACTTGAGTGATGTAG
+>374;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTGTCCGGATTTATTGGGTTTAAAGGCTACGTAGGCGGTGTATT
+AAGTCAGTGGTGAAAGCCTGCGGCTCAACCGTAGGAGTGCCATTGATACTGGTATACTTGAGTGTTGTAA
+>375;size=1;
+GTGCCAGCAGCCGCGGTAATACGAAGGGGGCTAGCGTTGCTCGGAATTACTGGGCGTAAAGGGAGCGTAGGCGGACATTT
+AAGTCAGGGGTGAAATCCCAGAGCTCAACTCTGGAACTGCCTTTGAAACTGCAAGTCTTGAGATCGGAAG
+>386;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGATGCGAGCGTTATCCGGATTTATTGGGTTTAAAGGGTGCGTAGGCGTAATGGT
+AAGTCAGTGGTGAAATCCTGCAGCTCAACTGTAGAGTTGCCATTGATACTGTCATTCTTGAGTATAGATG
+>387;size=1;
+GTGCCAGCAGCCGCGGTAATACGAAGGGGGCTAGCGTTGCTCGGAATTACAGGGCGTAAAGGGAGCGTAGGCGGACATTT
+AAGTCAGGGGTGAAATCCCAGAGCTCAACTCTGGAACTGCCTTTGATACTGGATGTCTTGAGTGTGAGAG
+>392;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTAACCGGAATTACTGGGCGTAAAGCGCATGCAGGCGGTTTGTT
+AAGTCAGATGTGAAAGCCCGGGGCTCAACCTCGGAACCGCATTTGAAACTGGCAGGCTAGAGTCTTGTAG
+>393;size=1;
+GTGCCAGCAGCCGCGGTAATACGTAGGGCGCAAGTGTTATCCGGAATTATTGGGCGTAAAGAGCTCGTAGGCGGTTTGTC
+GCGTCTGCCGTGAAAGTCCGGGGCTTAACTCCGGATCTGCGGTGGGTACGGGCAGACTTGAGTGATGTAG
+>397;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTGTCCGGATTTATTGGGTTTAAAGGGTACGTAGGCGGTGTATT
+AAGTCAGTGGTGAAAGCCTGCGGCTCAACCGTAGGAGTTCCATTGATACTGGTATACTTGAGTGTTGTAA
+>405;size=1;
+GTACCAGCAGCCGCGGTAATACGTAGGGCGCAAGCGTTATCCGGAATTATTGGGCGTAAAGAGCTCGTAGGCGGTTTGTC
+GCGTCTGCCGTGAAAGTCCGGGGCTTAACTCCGGATCTGCGGTGGGTACGGGCAGACTTGAGTGATGTAG
+>407;size=1;
+GTGCCAGCAGCCGCGGTAATACGAAGGGGGCTAGCGTTGCTCGGAATTACTGGGCGTAAAGGGTGCGTAGGTGGCGGGGT
+AAGTCAGGTGTGAAATCTCGGAGCTCAACTCCGAAACTGCACTTGATACTGCCTTGCTCGAGTACTGGAG
+>414;size=1;
+GTGCCAGCAGCCGCGGTAATACGTAGGGTGCGAGCGTTAATCGGAATTACTGGGTGTAAAGCGTGCGCAGGCGGCTACAT
+AAGACAGGTGTGAAATCCCCGGGCTCAACCTGGGAATGGCGCTTGTGACTGTGTGGCTTGAGTTCGGCAG
+>418;size=1;
+GTGCCAGCAGCCGCGGTAATACGTAGGGCGCAAGCGTTATCCGGAATTATTGGGCGTTAAGAGCTCGTAGGCGGTTTGTC
+GCGTCTGCCGTGAAAGTCCGGGGCTTAACTCCGGATCTGCGGTGGGTACGGGCAGACTTGAGTGATGTAG
+>423;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGATGCGAGCGTTATCCGGATTTATTGGGTTTAAAGGGTGCGTAGGCGGAATGGT
+AAGTCAGGTGTGAAATCTCGGAGCTCAACTCCGAAACTGCACTTGATACTGCCTTGCTCGAGTACTGGAG
+>431;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTAATCGGAATTACTGGGCGTAAAGCGCATGCAGGCGGTTTGTT
+AGGTCAGATGTGAAAGCCCGGGGCTCAACCTCGGAACCGCATTTGAAACTGGCAGGCTAGAGTCTTGTAG
+>436;size=1;
+GTGCCAGCAGCCGCGGTAATACGTAGGGCGTAAGCGTTATCCGGAATTATTGGGCGTAAAGAGCTCGTAGGCGGTTTGTC
+GCGTCTGCCGTGAAAGTCCGGGGCTTAACTCCGGATCTGCGGTGGGTACGGGCAGACTTGAGTGATGTAG
+>444;size=1;
+GTGCCAGCAGCCGCGGTAATACATAGGTCACAAGCGTTATCCGGATTTATTGGGCGTGAAGCGTTCGTAGGCGGTTTGTT
+AAGTCTAGAGTTAAAGCCTGGGGTTCAACCCCAGCCCGCTTTGGATACTGACAAACTAGAGTTACATAGA
+>445;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTGTCCGGATTTATTGGGTTTAAAGCGTACGTAGGCGGTGTATT
+AAGTCAGTGGTGAAAGCCTGCGGCTCAACCGTAGGAGTGCCATTGATACTGGTATACTTGAGTGTTGTAA
+>456;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGATGCGAGCGTTATCCGGATTTATTGGGTTTAAAGGGTGCGTAGGCGGAATGGT
+AAGCCAGTGGTGAAATCCTGCAGCTCAACTGTAGAGTTGCCATTGATACTGTCATTCTTGAGTATAGATG
+>460;size=1;
+GTGCCAGCAGCCGCGGTAATACGTAGGGTGCGAGCGTTAATCGGAATTACTGGGCGTAAAGCGTGCGCAGGCGGCTACAT
+CAGACAGGTGTGAAATCCCCGGGCTCAACCTGGGAATGGCGCTTGTGACTGTGTGGCTTGAGTTCGGCAG
+>469;size=1;
+GTGCCAGCAGCCGCGGTAATACGTAGGGGGCAAGCGTTGTCCGGATTTACTGGGTATAAAGGGCTCGCAGGCGGGTTTGT
+AAGTCAGAGGAGAAATCCTACAGCTTAACTGTAGAACTGCCTTTGAAACTGCAAGTCTTGAGATCGGAAG
+>470;size=1;
+GTGCCAGCAGCCGCGGTAATACAGAGGTCTCAAGCGTTGTTCGGATTCATTGGGCGTAAAGGGTGCGTAGGTGGCGGGGT
+AAGTCAGGTGTGAAATCTCGGAGCTCAACTCCGAAACTGCACTTGATACTGCCTTGCGCGAGTACTGGAG
+>477;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGATGCGAGCGTTATCCGGATTTATTGGGTTTAAAGGGTGCGTAGGCGGAATGGT
+AAGTCAGTGGTGAAATCCTGCGGCTCAACTGTAGAGTTGCCATTGATACTGTCATTCTTGAGTATAGATG
+>479;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGGGAGCGTTAATCGGAATTACTGGGCGTAAAGCGCATGCAGGCGGTTTGTT
+AAGTCAGATGTGAAAGCCCGGGGCTCAACCTCGGAACCGCATTTGAAACTGGCAGGCTAGAGTCTTGTAG
+>486;size=1;
+GTGCCAGCAGCTGCGGTAATACGTAGGGGGCAAGCGTTGTCCGGATTTACTGGGTATAAAGGGCTCGCAGGCGGGTTTGT
+AAGTCAGAGGTGAAATCCTACAGCTTAACTGTAGAACTGCCTTTGAAACTGCAAGTCTTGAGATCGGAAG
+>500;size=1;
+GTGCCAGCAGCCGCGGTAATACGTAGGGGGCAAGCGTTGTCCGGATTTACTGGGTATAAAGGGCTCGCAGGCGGGTTTGT
+AAGTCAGAGGTGAAATCCTACAGCTTAACTGTAGAACTGCCTTTGAAACTACAAGTCTTGAGATCGGAAG
+>515;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGATGCGAGCGTTATCCGGATTTATTGGGTTTAAAGGGTGCGTAGGCGGAATGGT
+AAGTCAGTGGTGCAATCCTGCAGCTCAACTGTAGAGTTGCCATTGATACTGTCATTCTTGAGTATAGATG
+>516;size=1;
+GTGCCAGCAGCCGCGGTAATACATAGGTCACAAGCGTTATCCGGATTTATTGGGCGTAAAGGGTGCGTAGGTGGCGGGGT
+AAGTCAGGTGTGAAATCTCGGAGCTCAACTCCGAAACTGCACTTGATACTGCCTTGCTCGAGTACTGGAG
+>528;size=1;
+GTTCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTGTCCGGATTTATTGGGTTTAAAGGGTACGTAGGCGGTGTATT
+AAGTCAGTGGTGAAAGCCTGCGGCTCAACCGTAGGAGTGCCATTGATACTGGTATACTTGAGTGTTGTAA
+>530;size=1;
+GTGCCAGCAGGCGCGGTAATACGAAGGGGGCTAGCGTTGCTCGGAATTACTGGGCGTAAAGGGAGCGTAGGCGGACATTT
+AAGTCAGGGGTGAAATCCCAGAGCTCAACTCTGGAACTGCCTTTGATACTGGATGTCTTGAGTGTGAGAG
+>531;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTAATCGGAATTACTGGGCGTAAAGCGCATGCAGGCGGTTTGTT
+AAGTCAGATGTGAAAGCCCGGGGCTCAACCTCGGAACCGCATTTGAAACTGGCAGGCTAGAGGCTTGTAG
+>549;size=1;
+GTCCCAGCAGCCGCGGTAATACGTAGGGGGCAAGCGTTGTCCGGATTTACTGGGTATAAAGGGCTCGCAGGCGGGTTTGT
+AAGTCAGAGGTGAAATCCTACAGCTTAACTGTAGAACTGCCTTTGAAACTGCAAGTCTTGAGATCGGAAG
+>551;size=1;
+GTGCCAGCAGCCGCGGTAATACAGAGGTCTCAAGCGTTGTTCGGATTCATTGGGCGTAAAGGGTGCGTAGGTGGCGGGGT
+AAGTCAGGTGTGAAATCTCGGAGCTCAACTCCGAAACTGCAGTTGATACTGCCTTGCTCGAGTACTGGAG
+>557;size=1;
+GTGCCAGCAGCCGCTGTAATACGTAGGGCGCAAGCGTTATCCGGAATTATTGGGCGTAAAGAGCTCGTAGGCGGTTTGTC
+GCGTCTGCCGTGAAAGTCCGGGGCTTAACTCCGGATCTGCGGTGGGTACGGGCAGACTTGAGTGATGTAG
+>559;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTGTCCGGATTTATTGGGCTTAAAGGGTACGTAGGCGGTGTATT
+AAGTCAGTGGTGAAAGCCTGCGGCTCAACCGTAGGAGTGCCATTGATACTGGTATACTTGAGTGTTGTAA
+>561;size=1;
+GTGCCAGCAGCCGCGGTAATACGTAGGGGGCAAGCGTTGTCCGGATTTACTGGGTATAAAGGGCTCGCAGGCGGGTTTGT
+AAGTCAGAGGTGAAATCCTACAGCTTAACTGTAGAACTGCCTTTGAAACTGCATGTCTTGAGATCGGAAG
+>562;size=1;
+GTGCCAGCAGCCGCGGTAATACGAAGGGGGCTAGCGTTGCTCGGAATTACTGGGCGTAAAGGGAGCGTAGGCGGACATTT
+AAGTCAGGGGTGAAATCCCAGAGCTCAACTCTGGAACTGCCATTGATACTGGATGTCTTGAGTGTGAGAG
+>564;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGATGCGAGCGTTATCCGGATTTATTGGGTTTAAAGGGTGCGTAGGCGGAATGGT
+AAGTCAGTGGTGAAATCCTGCAGCTCAACTGTAGAATTGCCATTGATACTGTCATTCTTGAGTATAGATG
+>566;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTGTCCGGATTTAATGGGTTTAAAGGGTACGTAGGCGGTGTATT
+AAGTCAGTGGTGAAAGCCTGCGGCTCAACCGTAGGAGTGCCATTGATACTGGTATACTTGAGTGTTGTAA
+>568;size=1;
+GTGCCAGCAGCCGCGGTAATACAGAGGTCTCAAGCGTTGTTCGGATTCATTGGGCGTAAAGGGTGCGTAGGTGGCGGGGT
+AAGTCAGGTGTGAAATCTCGGAGCTTAACTCCGAAACTGCACTTGATACTGCCTTGCTCGAGTACTGGAG
+>57;size=1;
+GTGCCAGCAGCCGCGGTAATACAGAGGTCTCAAGCGTTGTTCGGATTCATTGGGCGTAAAGGGTGCGTAGGTGGAGGGGT
+AAGTCAGGTGTGAAATCTCGGAGCTCAACTCCGAAACTGCACTTGATACTGCCTTGCTCGAGTACTGGAG
+>570;size=1;
+GTGCCAGCAGCCGCGGTAATACATAGGTCACAAGCGTTATCCGGATTTATTGGGCGTAAAGCGTTCGTAGGCGGTTTGTT
+AAGTCTAGAGTTAAAGCCTGGGGTTCAACCCCAGCCCGCTTTGGATACTGACAAACTAGCGTTACATAGA
+>578;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGATGCGAGCGTTATCCGGATGTATTGGGTTTAAAGGGTGCGTAGGCGGAATGGT
+AAGTCAGTGGTGAAATCCTGCAGCTCAACTGTAGAGTTGCCATTGATACTGTCATTCTTGAGTATAGATG
+>586;size=1;
+GTGCCAGCAGCCGCGGTAATACGAAGGGGGCTAGCGTTGCTCGGAATTACTGGGCGTAAAGGGAGCGTAGGCGGACATTT
+AAGTCAGGGGTGAAATCCCAGAGCTCAACTCTGGAACTGCCTTTGATACTGGATATCTTGAGTGTGAGAG
+>587;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGATGCGAGCGTTATCCGGATTTATTGGGTTTAAAGGGTACGTAGGCGGTGTATT
+AAGTCAGTGGTGAAAGCCTGCGGCTCAACCGTAGGAGTGCCATTGATACTGGTATACTTGAGTGTTGTAA
+>596;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTGTCCGGATTTATTGTGTTTAAAGGGTACGTAGGCGGTGTATT
+AAGTCAGTGGTGAAAGCCTGCGGCTCAACCGTAGGAGTGCCATTGATACTGGTATACTTGAGTGTTGTAA
+>600;size=1;
+GTGCCAGCAGCCGCGGTAATACGTAGGGGGCAAGCGTTGTCCGGTTTTACTGGGTATAAAGGGCTCGCAGGCGGGTTTGT
+AAGTCAGAGGTGAAATCCTACAGCTTAACTGTAGAACTGCCTTTGAAACTGCAAGTCTTGAGATCGGAAG
+>612;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGATGCGAGCGTTATCCGGATTTATTGGGTTTAAAGGGTGCGTAGGCAGAATGGT
+AAGTCAGTGGTGAAATCCTGCAGCTCAACTGTAGAGTTGCCATTGATACTGTCATTCTTGAGTATAGATG
+>618;size=1;
+GTGCCAGCAGCCGCGGTAATACATAGGTCACCAGCGTTATCCGGATTTATTGGGCGTAAAGCGTTCGTAGGCGGTGTATT
+AAGTCAGTGGTGAAAGCCTGCGGCTCAACCGTAGGAGTGCCATTGATACTGGTATACTTGAGTGTTGTAA
+>625;size=1;
+GTGCCAGCAGCCGCGGTAATACAGAGGTCTCAAGCGTTATTCGGATTCATTGGGCGTAAAGGGTGCGTAGGTGGCGGGGT
+AAGTCAGGTGTGAAATCTCGGAGCTCAACTCCGAAACTGCACTTGATACTGCCTTGCTCGAGTACTGGAG
+>632;size=1;
+GTGCCAGCAGCCGCGGTAATACGTAGGGCGCAAGCGTTATCCGGAATTATTGGGCGTAAAGAGCTCGTAGGCGGTTTGTC
+GCGTCTGCCGTGAAAGTCCGGGGCTTAACTCCGGATCTGCGGTGGGTACGCGCAGACTTGAGTGATGTAG
+>649;size=1;
+GTGCCAGCAGCCGCGGTAATACGTAGGGTGCGAGCGTTAATCGGAATTACTGGGCGTAAAGCGTGCGCAGGCGGCGACAT
+AAGACAGGTGTGAAATCCCCGGGCTCAACCTGGGAATGGCGCTTGTGACTGTGTGGCTTGAGTTCGGCAG
+>650;size=1;
+GTGCCAGCAGCCGTGGTAATACGTAGGGGGCAAGCGTTGTCCGGATTTACTGGGTATAAAGGGCTCGCAGGCGGGTTTGT
+AAGTCAGAGGTGAAATCCTACAGCTTAACTGTAGAACTGCCTTTGAAACTGCAAGTCTTGAGATCGGAAG
+>651;size=1;
+GTGCCAGCAGCCGCGGTAATACGTAGGGCGCAAGCGTTATCCGGAATTATTGGGCGTAAAGAGCTCGTAGGCGGTTTGTC
+GCGTCTGCCGTGAAAGTCCGGGGCTTAACTCCGGATCTGCGGTGGGTACCGGCAGACTTGAGTGATGTAG
+>66;size=1;
+GTGCCAGCAGCCGCGGTAATACATAGGTCACAAGCGTTATCCGGATTTATTGGGCGTAAAGCGTTGGTAGGCGGTTTGTT
+AAGTCTAGAGTTAAAGCCTGGGGTTCAACCCCAGCCCGCTTTGGATACTGACAAACTAGAGTTACATAGA
+>664;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTGTCCGGATTGATTGGGTTTAAAGGGTACGTAGGCGGTGTATT
+AAGTCAGTGGTGAAAGCCTGCGGCTCAACCGTAGGAGTGCCATTGATACTGGTATACTTGAGTGTTGTAA
+>673;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTAATCGGAATTACTGCGCGTAAAGCGCACGCAGGCGGTTAATT
+AAGCTAGAAGTGAAAGCCCTGCGCTCAACGTGGGAAGGCCTTTTAGAACTGGTTAACTAGAGTATTGGAG
+>675;size=1;
+GTGCCAGCAGCCGCGGTAATACCTAGGTCACAAGCGTTATCCGGATTTATTGGGCGTAAAGCGTTCGTAGGCGGTTTGTT
+AAGTCTAGAGTTAAAGCCTGGGGTTCAACCCCAGCCCGCTTTGGATACTGACAAACTAGAGTTACATAGA
+>682;size=1;
+GTGCCAGCAGCCGCGGTAATACGTAGGGGGCAAGCGTTGTCCGGATTTACTGGGTATAAAGGGCTCGCAGGCGGGTTTTT
+AAGTCAGAGGTGAAATCCTACAGCTTAACTGTAGAACTGCCTTTGAAACTGCAAGTCTTGAGATCGGAAG
+>690;size=1;
+GTGCCAGCAGCCGCGGTAATACAGAGGTCTCAAGCGTTGTTCGGATTCATTGGGCGTAAAGGGTGCGTAGGTGGCGGGGT
+AAGTCAGGTGTGAAATCTCGGAGCTCAACTCCGAAACTGCACTGGATACTGCCTTGCTCGAGTACTGGAG
+>699;size=1;
+GTTCCAGCAGCCGCGGTAATACGGAGGATGCGAGCGTTATCCGGATTTATTGGGTTTAAAGGGTGCGTAGGCGGAATGGT
+AAGTCAGTGGTGAAATCCTGCAGCTCAACTGTAGAGTTGCCATTGATACTGTCATTCTTGAGTATAGATG
+>7;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGATGCGAGCGTTATCCGGATTTATTGGGTTTAAAGGGTGCATAGGCGGAATGGT
+AAGTCAGTGGTGAAATCCTGCAGCTCAACTGTAGAGTTGCCATTGATACTGTCATTCTTGAGTATAGATG
+>709;size=1;
+GTGCCAGCAGCCGCGGTAATACGTAGGGTGCGAGCGTTAATCGGAATTACTGGGCGTAAAGCGTGCGCAGGCGGCTACAT
+AAGACAGGTGTGAAATCCCCGGGCTCAACCTGGGAATGGCGCTTGTGACTGTCTGGCTTGAGTTCGGCAG
+>717;size=1;
+GTGCCAGCAGCCGCGGTAATACATAGGTCACAAGCGTTATCCGGATTTATTGGGCGTAAAGCGTGCGCAGGCGGCTACAT
+AAGACAGGTGTGAAATCCCCGGGCTCAACCTGGGAATGGCGCTTGTGACTGTGTGGCTTGAGTTCGGCAG
+>73;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTAATCGGAATTACTGGGCGTAAAGCGCATGCAGGCGGTTTGTT
+AAGTCAGATGTGAAAGCCCGGGGCTCAACCGCGGAACCGCATTTGAAACTGGCAGGCTAGAGTCTTGTAG
+>740;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTAATCGGAATTACTGGGCGTAAAGCGCATGCAGGCGGTTTGTT
+AAGTCAGATGTGAAAGCCCGTGGCTCAACCTCGGAACCGCATTTGAAACTGGCAGGCTAGAGTCTTGTAG
+>745;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTAATCGGAATTACTGAGCGTAAAGCGCACGCAGGCGGTTAATT
+AAGCTAGAAGTGAAAGCCCTGCGCTCAACGTGGGAAGGCCTTTTAGAACTGGTTAACTAGAGTATTGGAG
+>746;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTAATCGGAATTACTGGTCGTAAAGCGCATGCAGGCGGTTTGTT
+AAGTCAGATGTGAAAGCCCGGGGCTCAACCTCGGAACCGCATTTGAAACTGGCAGGCTAGAGTCTTGTAG
+>748;size=1;
+GTGCCAGCAGCCGCGGTAATACATAGGTCACAAGCGTTATCCGGATTTATTGGGCGTAAAGCATTCGTAGGCGGTTTGTT
+AAGTCTAGAGTTAAAGCCTGGGGTTCAACCCCAGCCCGCTTTGGATACTGACAAACTAGAGTTACATAGA
+>760;size=1;
+GTGCCAGCAGCCGCGGTAATACAGAGGTCTCAAGCGTTGTTCGGATTCATTGCGCGTAAAGGGTGCGTAGGTGGCGGGGT
+AAGTCAGGTGTGAAATCTCGGAGCTCAACTCCGAAACTGCACTTGATACTGCCTTGCTCGAGTACTGGAG
+>766;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTGTCCGGATTTATTGGGTTTAAAGGGTACGTAGGCGGTGTATT
+AAGTCAGTGGTGAAAGCCTGCGGCTCAACCGTAGGAGTGCCATTAATACTGGTATACTTGAGTGTTGTAA
+>77;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTGTCGGGATTTATTGGGTTTAAAGGGTACGTAGGCGGTGTATT
+AAGTCAGTGGTGAAAGCCTGCGGCTCAACCGTAGGAGTGCCATTGATACTGGTATACTTGAGTGTTGTAA
+>778;size=1;
+GTGCCAGCAGCCGCGGTAATACATAGGTCACAAGCGTTATCCGGATTTATTGGGCGTAAAGCGTTTGTAGGCGGTTTGTT
+AAGTCTAGAGTTAAAGCCTGGGGTTCAACCCCAGCCCGCTTTGGATACTGACAAACTAGAGTTACATAGA
+>791;size=1;
+GTGCCAGCAGCCGCGGTAATACGAAGGGGGCTAGCGTTGCTCGGAATTACTGGGCGTAAAGGGAGCGTAGGCGGACATTT
+TAGTCAGGGGTGAAATCCCAGAGCTCAACTCTGGAACTGCCTTTGATACTGGATGTCTTGAGTGTGAGAG
+>797;size=1;
+GTGCCAGCAGCCGCGGTAATACGTAGGGTGCGAGCGTTAATCGGAATTACTGGGCGTAAAGCGTGCGCAGGCGGCTACAT
+AAGACAGGTGTGAAATCCCCGGGCTCAACCTGGGAATGGCGCTTGTGACTGTTTGGCTTGAGTTCGGCAG
+>809;size=1;
+GTGCCAGCAGCCGCGGTAATACAGAGGTCTCAAGCGTTGTTCGGATTCATTGAGCGTAAAGGGTGCGTAGGTGGCGGGGT
+AAGTCAGGTGTGAAATCTCGGAGCTCAACTCCGAAACTGCACTTGATACTGCCTTGCTCGAGTACTGGAG
+>813;size=1;
+GTGCCAGCAGCCGCGGTAATACGTAGGGGGCAAGCGTTGTCCGGATTTACTGGGTATAAAGGGCTCGCAGGCGGGTTTGT
+AAGTCAGAGGTGAAATCCTACAGCTTAACAGTAGAACTGCCTTTGAAACTGCAAGTCTTGAGATCGGAAG
+>814;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGGGGCAAGCGTTGTCCGGATTTACTGGGTATAAAGGGCTCGCAGGCGGGTTTGT
+AAGTCAGAGGTGAAATCCTACAGCTTAACTGTAGAACTGCCTTTGAAACTGCAAGTCTTGAGATCGGAAG
+>816;size=1;
+GTGCCAGCAGCCGCGGTAATACGTAGGGTGCGAGCGTTAATCGGAATTACTGGGCGTAAAGCGTGCGCAGGCGGCTACAT
+AAGACAGGTGTGAAATCCCCGGGCTCAACCTGAGAATGGCGCTTGTGACTGTGTGGCTTGAGTTCGGCAG
+>817;size=1;
+GTGCCAGCAGCCGCGGTAATACGTAGGGTGCGAGCGTTAATCGGAATTACTGGGCGTAAAGCGCATGCAGGCGGTTTGTT
+AAGTCAGATGTGAAAGCCCGGGGCTCAACCTCGGAACCGCATTTGAAACTGGCAGGCTAGAGTCTTGTAG
+>82;size=1;
+GTGCCAGCAGGCGCGGTAATACGGAGGGTGCGAGCGTTGTCCGGATTTATTGGGTTTAAAGGGTACGTAGGCGGTGTATT
+AAGTCAGTGGTGAAAGCCTGCGGCTCAACCGTAGGAGTGCCATTGATACTGGTATACTTGAGTGTTGTAA
+>821;size=1;
+GTGCCAGCAGCCGCGGTAATACAGAGGTCTCAAGCGTTGTTCGGATTCATTGGGCGTAAAGGGTGCGTAGGTGGCGGGGT
+AAGTCAGGTGTGAAATCTCGGAGCTCAACTCCGAAACTGCACTTGATACTGCCTTGCTCGTGTACTGGAG
+>824;size=1;
+GTGCCAGCAGCCGCGGTAATACGTAGGGTGCGAGTGTTAATCGGAATTACTGGGCGTAAAGCGTGCGCAGGCGGCTACAT
+AAGACAGGTGTGAAATCCCCGGGCTCAACCTGGGAATGGCGCTTGTGACTGTGTGGCTTGAGTTCGGCAG
+>827;size=1;
+GTGCCAGCAGCCGCGGTAATACGTAGGGTGCGAGCGTTAATCGGAATTAGTGGGCGTAAAGCGTGCGCAGGCGGCTACAT
+AAGACAGGTGTGAAATCCCCGGGCTCAACCTGGGAATGGCGCTTGTGACTGTGTGGCTTGAGTTCGGCAG
+>83;size=1;
+GTGCCAGCAGCCGCGGTAATACGAAGGGGGCTAGCGTTGCTCGGAATTACTGGGCGTAAAGGGAGCGTAGGCGGACATTT
+AAGTCAGGGGTGAAATCCCAGAGCTCAACTCTGGAAGTGCCTTTGATACTGGATGTCTTGAGTGTGAGAG
+>842;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGGGCGTTGTCCGGATTTATTGGGTTTAAAGGGTACGTAGGCGGTGTATT
+AAGTCAGTGGTGAAAGCCTGCGGCTCAACCGTAGGAGTGCCATTGATACTGGTATACTTGAGTGTTGTAA
+>851;size=1;
+GTGCCAGCAGCCGCGGTAATACAGAGGTCTCAAGCGTTGTTCGGATTCATTGGGCGTAAAGGGTGCGTAGGTGTCGGGGT
+AAGTCAGGTGTGAAATCTCGGAGCTCAACTCCGAAACTGCACTTGATACTGCCTTGCTCGAGTACTGGAG
+>853;size=1;
+GTTCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTAATCGGAATTACTGGGCGTAAAGCGCACGCAGGCGGTTAATT
+AAGCTAGAAGTGAAAGCCCTGCGCTCAACGTGGGAAGGCCTTTTAGAACTGGTTAACTAGAGTATTGGAG
+>862;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTGTCCGGATTTATTGGGTTTAAAGGGTACGTAGGCGGTGTATT
+AAGTCAGTGGTGAAAGCCTGCGGCTCAACCGTAGGAGTGCCATTGATACTGGTATACTGGAGTGTTGTAA
+>863;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGATGCGAGCGTTATCCGGATTTATTGGGTTTAAAGGGTGCGTAGGCGGAATGGT
+AAGTCAGTGGTGAAATCCTGCAGCTGAACTGTAGAGTTGCCATTGATACTGTCATTCTTGAGTATAGATG
+>866;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTGATCGGAATTACTGGGCGTAAAGCGCATGCAGGCGGTTTGTT
+AAGTCAGATGTGAAAGCCCGGGGCTCAACCTCGGAACCGCATTTGAAACTGGCAGGCTAGAGTCTTGTAG
+>871;size=1;
+GCGCCAGCAGCCGCGGTAATACAGAGGTCTCAAGCGTTGTTCGGATTCATTGGGCGTAAAGGGTGCGTAGGTGGCGGGGT
+AAGTCAGGTGTGAAATCTCGGAGCTCAACTCCGAAACTGCACTTGATACTGCCTTGCTCGAGTACTGGAG
+>879;size=1;
+GTGCCAGCAGCCGCGGTAATACGTAGGGCGCAAGCGTTATCCGGAATTATTGGGCGTAAAGAGCTCGTAGGCGGTTTGTC
+GCGTCTGCTGTGAAAGTCCGGGGCTTAACTCCGGATCTGCGGTGGGTACGGGCAGACTTGAGTGATGTAG
+>886;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGATGCGAGCGTTATCCGGATTTATTGGGTTTAAAGGGTGCGTAGGCGGAATGGT
+AAGTCAGTGGTGAAATCCTGCAGCTCAACTGTAGAGTTGCCATTGATACTGTCATTCTTGAGTATAGAGG
+>892;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTAATCGGAATTACTGGGCGTAAAGCGCATGCAGGCGGTTTGTT
+AAGTCAGATGTGAAAGCCCGGGGCTCAACCTCGGAACCGCATTTGAAACTGGGAGGCTAGAGTCTTGTAG
+>895;size=1;
+GTGCCAGCAGCCGCGGTAATACGAAGGGGGCTAGCGTTGCTCGGAATTACTGGGCGTAAAGGGATCGTAGGCGGACATTT
+AAGTCAGGGGTGAAATCCCAGAGCTCAACTCTGGAACTGCCTTTGATACTGGATGTCTTGAGTGTGAGAG
+>897;size=1;
+GTGCCAGCAGCCGCGGTAATACATAGGTCACAAGCGTTATCCGGAATTATTGGGCGTAAAGCGTTCGTAGGCGGTTTGTT
+AAGTCTAGAGTTAAAGCCTGGGGTTCAACCCCAGCCCGCTTTGGATACTGACAAACTAGAGTTACATAGA
+>902;size=1;
+GTGCCAGCAGCCGCGGTAATACGTAGGGTGCGAGCGTTAATCGGAATTACTGGGCGTAAAGCGTGCGCAGGCGGCTACAT
+AAGACAGGTGTGAAATCTCGGAGCTCAACTCCGAAACTGCACTTGATACTGCCTTGCTCGAGTACTGGAG
+>904;size=1;
+CTGCCAGCAGCCGCGGTAATACAGAGGTCTCAAGCGTTGTTCGGATTCATTGGGCGTAAAGGGTGCGTAGGTGGCGGGGT
+AAGTCAGGTGTGAAATCTCGGAGCTCAACTCCGAAACTGCACTTGATACTGCCTTGCTCGAGTACTGGAG
+>91;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTGTCCGGATTTATTGGGTTTAAAGGGTACGTAGGCGGTGTATT
+AAGTCAGTGGTGAAAGCCTGCGGCTCAACCGTAGGAGTGCCATTGATACTGGTATACTTGAGTGTTGTAC
+>912;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTAATCGGAATTACTGGGCGTAAAGCGCACGCAGGCGGTTAATT
+AAGCTAGAAGTGAAAGCCCTGCGCTCAACGTGGGAAGGCATTTTAGAACTGGTTAACTAGAGTATTGGAG
+>916;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGATGCGAGCGTTATCCGGATTTATTGGGTTTAAAGGGTGCGTAGGCGGAATGGT
+AAGTCAGGGGTGAAATCCTGCAGCTCAACTGTAGAGTTGCCATTGATACTGTCATTCTTGAGTATAGATG
+>918;size=1;
+GTGCCAGCAGCCGCGGTAATACATAGGTCACAAGCGTTATCCGGATTTATTGGGTTTAAAGGGTGCGTAGGCGGAATGGT
+AAGTCAGTGGTGAAATCCTGCAGCTCAACTGTAGAGTTGCCATTGATACTGTCATTCTTGAGTATAGATG
+>920;size=1;
+GTGCCAGCAGCCGCGGTAATACGTCGGGGGCAAGCGTTGTCCGGATTTACTGGGTATAAAGGGCTCGCAGGCGGGTTTGT
+AAGTCAGAGGTGAAATCCTACAGCTTAACTGTAGAACTGCCTTTGAAACTGCAAGTCTTGAGATCGGAAG
+>921;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTGTCCGGATTTATTGCGTTTAAAGGGTACGTAGGCGGTGTATT
+AAGTCAGTGGTGAAAGCCTGCGGCTCAACCGTAGGAGTGCCATTGATACTGGTATACTTGAGTGTTGTAA
+>925;size=1;
+GTGCCAGCAGCCGCGGTAATACAGAGGTCTCAAGCGTTGTTCGGATTCATTGGGCGTAAAGGGTGCGGAGGTGGCGGGGT
+AAGTCAGGTGTGAAATCTCGGAGCTCAACTCCGAAACTGCACTTGATACTGCCTTGCTCGAGTACTGGAG
+>930;size=1;
+GTGCCAGCAGCCGCGGTAATACATAGGGGGCAAGCGTTGTCCGGATTTACTGGGTATAAAGGGCTCGCAGGCGGGTTTGT
+AAGTCAGAGGTGAAATCCTACAGCTTAACTGTAGAACTGCCTTTGAAACTGCAAGTCTTGAGATCGGAAG
+>941;size=1;
+GTGCCAGCAGCCGCGGTAATACAGAGGTCTCAAGCGTTGTTCGGATTCATTGGGCGTAAAGGGTGCGTAGGTGGCGGGGT
+AAGTCAGGTGTGAAATCTCGGAGCTCAACTCTGGAACTGCCTTTGATACTGGATGTCTTGAGTGTGAGAG
+>942;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTAATCGGAATTACTGGGCGTAAAGCGCACGCAGGCGGTTAATT
+AAGCTAGAAGTGAAAGCCCTGCGCTCAACGTGGGAAGGCCTTTTAGAACTGGTTAACTATAGTATTGGAG
+>945;size=1;
+GTGCCAGCAGCCGTGGTAATACGTAGGGTGCGAGCGTTAATCGGAATTACTGGGCGTAAAGCGTGCGCAGGCGGCTACAT
+AAGACAGGTGTGAAATCCCCGGGCTCAACCTGGGAATGGCGCTTGTGACTGTGTGGCTTGAGTTCGGCAG
+>947;size=1;
+GTGCCAGCAGCCGCGGTAATACGTAGGGCGCAAGCGTCATCCGGAATTATTGGGCGTAAAGAGCTCGTAGGCGGTTTGTC
+GCGTCTGCCGTGAAAGTCCGGGGCTTAACTCCGGATCTGCGGTGGGTACGGGCAGACTTGAGTGATGTAG
+>948;size=1;
+GTGCCAGCAGCCGCGGTAATACATAGGTCACAAGCGTTATCCGGATTTATTGGGCGTAAAGCGTTCGTAGGCGGTTTGTT
+AAGTCTAGAGTTAAAACCTGGGGTTCAACCCCAGCCCGCTTTGGATACTGACAAACTAGAGTTACATAGA
+>952;size=1;
+GTGCCAGCAGCCGCGGTAATACAGAGGTCTCAAGCGTTGTTCGGATTCATTGGGCGTAAAGGGTGCGTAGGTGGCGGGGT
+AAGTCAGGCGTGAAATCTCGGAGCTCAACTCCGAAACTGCACTTGATACTGCCTTGCTCGAGTACTGGAG
+>956;size=1;
+GTGCCAGCAGCCGCGGTAATACGAAGGGGGCTAGCGTTGCTCGGAATTACTGGGCGTAAAGGGAGCGTAGGCGGACATTT
+AAGTCAGGGGTGAAATCCCAGAGCTCAACTCTGGAACTGCGTTTGATACTGGATGTCTTGAGTGTGAGAG
+>958;size=1;
+GTGCCAGCAGCCGCGGTAATACGTAGGGCGCAAGCGTTATCCCGAATTATTGGGCGTAAAGAGCTCGTAGGCGGTTTGTC
+GCGTCTGCCGTGAAAGTCCGGGGCTTAACTCCGGATCTGCGGTGGGTACGGGCAGACTTGAGTGATGTAG
+>964;size=1;
+GTGCCAGCAGCCGCCGTAATACGGAGGGTGCGAGCGTTAATCGGAATTACTGGGCGTAAAGCGCACGCAGGCGGTTAATT
+AAGCTAGAAGTGAAAGCCCTGCGCTCAACGTGGGAAGGCCTTTTAGAACTGGTTAACTAGAGTATTGGAG
+>967;size=1;
+GTGCCAGCAGCCGCGGTAATACAGAGGTCTCAAGCGTTGTTCGGATTCATTGGGCGTAAAGGGTGCGTAGGTGGCGGGGT
+AAGTCAGGTGTGAAATCTCGGAGCTCAACTCCGAAACTGCACTTGATACTGCCTTGCTCGAGTACTAGAG
+>984;size=1;
+GTGCCAGCAGCCGCGGTAATACGGAGGATGCGAGCGTTATCCGGATTTATTGGGTTTAAAGGGTGCGTAGGCGGAATGGT
+AAGTCAGTGGTGAAATCCTGCAGCTCAACTGTAGAGTTGCCATTGATACTGTCATTCTTGAGTAGAGATG
+>992;size=1;
+GTGCCAGCAGCCGCGGTAATACAGAGGTCTCAAGCGTTGTTCGGATTCATTGGGCGTAAAGGGTGCGTAGGTGGCGGGGT
+AAATCAGGTGTGAAATCTCGGAGCTCAACTCCGAAACTGCACTTGATACTGCCTTGCTCGAGTACTGGAG
+>993;size=1;
+GTGCCAGCAGCCGCGGTAATACGTAGGGTGCGAGCGTTAATCGGAATTACTGGGCGTAAAGCGTGCGCAGGCGACTACAT
+AAGACAGGTGTGAAATCCCCGGGCTCAACCTGGGAATGGCGCTTGTGACTGTGTGGCTTGAGTTCGGCAG
+"""
+
+# Single chimeric sequence (251) with both parents to test alignment
+# and tabular output de novo
+single_chimera = """>22;size=93;
+GTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTGTCCGGATTTATTGGGTTTAAAGGGTACGTAGGCGGTGTATT
+AAGTCAGTGGTGAAAGCCTGCGGCTCAACCGTAGGAGTGCCATTGATACTGGTATACTTGAGTGTTGTAA
+>45;size=67;
+GTGCCAGCAGCCGCGGTAATACGGAGGATGCGAGCGTTATCCGGATTTATTGGGTTTAAAGGGTGCGTAGGCGGAATGGT
+AAGTCAGTGGTGAAATCCTGCAGCTCAACTGTAGAGTTGCCATTGATACTGTCATTCTTGAGTATAGATG
+>251;size=2;
+GTGCCAGCAGCCGCGGTAATACGGAGGATGCGAGCGTTATCCGGATTTATTGGGTTTAAAGGGTGCGTAGGCGGAATGGT
+AAGTCAGTGGTGAAATCCTGCAGCTCAACTGTAGAGTTGCCATTGATACTGGTATACTTGAGTGTTGTAA
+"""
+
+# Alignment for chimeric sequence (251) against parents (22 and 45) de novo
+single_chimera_aln = """
+------------------------------------------------------------------------
+Query   (  150 nt) 251;size=2;
+ParentA (  150 nt) 45;size=67;
+ParentB (  150 nt) 22;size=93;
+
+A     1 GTGCCAGCAGCCGCGGTAATACGGAGGATGCGAGCGTTATCCGGATTTATTGGGTTTAAAGGGTGCGTAGGCGGAATGGT 80
+Q     1 GTGCCAGCAGCCGCGGTAATACGGAGGATGCGAGCGTTATCCGGATTTATTGGGTTTAAAGGGTGCGTAGGCGGAATGGT 80
+B     1 GTGCCAGCAGCCGCGGTAATACGGAGGgTGCGAGCGTTgTCCGGATTTATTGGGTTTAAAGGGTaCGTAGGCGGtgTatT 80
+Diffs                              A          A                         A         AA AA 
+Votes                              +          +                         +         ++ ++ 
+Model   AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+
+A    81 AAGTCAGTGGTGAAATCCTGCAGCTCAACTGTAGAGTTGCCATTGATACTGtcATtCTTGAGTaTaGatg 150
+Q    81 AAGTCAGTGGTGAAATCCTGCAGCTCAACTGTAGAGTTGCCATTGATACTGGTATACTTGAGTGTTGTAA 150
+B    81 AAGTCAGTGGTGAAAgCCTGCgGCTCAACcGTAGgagTGCCATTGATACTGGTATACTTGAGTGTTGTAA 150
+Diffs                  A     A       A    AAA              BB  B       B B BBB
+Votes                  +     +       +    +++              ++  +       + + +++
+Model   AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxxxxxxxxxxxxxxBBBBBBBBBBBBBBBBBBB
+
+Ids.  QA 94.7%, QB 91.3%, AB 86.0%, QModel 100.0%, Div. +5.6%
+Diffs Left 13: N 0, A 0, Y 13 (100.0%); Right 8: N 0, A 0, Y 8 (100.0%), Score 0.8291
+"""
+
+# Tabular format for UCHIME output
+single_chimera_tab = """0.0000\t22;size=93;\t*\t*\t*\t*\t*\t*\t*\t*\t0\t0\t0\t0\t0\t0\t*\tN
+0.0000\t45;size=67;\t*\t*\t*\t*\t*\t*\t*\t*\t0\t0\t0\t0\t0\t0\t*\tN
+0.8291\t251;size=2;\t45;size=67;\t22;size=93;\t45;size=67;\t100.0\t94.7\t91.3\t86.0\t94.7\t13\t0\t0\t8\t0\t0\t5.3\tY
+"""
+
+# Single chimeric sequence for reference chimera checking
+single_chimera_ref = """>251;size=2;
+GTGCCAGCAGCCGCGGTAATACGGAGGATGCGAGCGTTATCCGGATTTATTGGGTTTAAAGGGTGCGTAGGCGGAATGGT
+AAGTCAGTGGTGAAATCCTGCAGCTCAACTGTAGAGTTGCCATTGATACTGGTATACTTGAGTGTTGTAA 
+"""
+
+# Reference database for UCHIME ref
+uchime_ref_db = """>4304512
+TGAGTTTGATCCTGGCTCAGAACGAACGCTGGCGGCAGGCCTAACACATGCAAGTCGAACGCGTCCTTCGGGACGAGTGGCAGACGGGTGAGTAACGCGTGGGAACGTACCCTTTGGTTCGGAACAACTCCGGGAAACTGGAGCTAATACCGGATAAGCCCTTCGGGGGAAAGATTTATCGCCTTTAGAGCGGCCCGCGTCTGATTAGCTAGTTGGTGGTGTAATGGACCACCAAGGCGACGATCAGTAGCTGGTCTGAGAGGATGACCAGCCACATTGGGACTGAGACACGGCTCAAACTCCTACGGGAGGCAGCAGTGGGGAATCTTGCGCAATGGGCGAAAGCCTGACGCAGCCATGCCGCGTGTATGATGAAGGTCTTAGGATTGTAAAATACTTTCACCGGTGAAGATAATGACTGTAGCCGGAGAAGAAGCCCCGGCTAACTTCGTGCCAGCAGCCGCGGTAATACGAAGGGGGCTAGCGTTGCTCGGAATTACTGGGCGTAAAGGGAGCGTAGGCGGACATTTAAGTCAGGGGTGAAATCCCAGAGCTCAACTCTGGAACTGCCTTTGATACTGGATGTCTTGAGTGTGAGAGAGGTATGTGGAACTCCGAGTGTAGAGGTGAAATTCGTAGATATTCGGAAGAACACCAGTGGCGAAGGCGACATACTGGCTCATTACTGACGCTGAGGCTCGAAAGCGTGGGGAGCAAACAGGATTAGATACCCTGGTAGTCCACGCCGTAAACGATGATTGCTAGTTGTCGGGATGCATGCATTTCGGTGACGCAGCTAACGCATTAAGCAATCCGCCTGGGGAGTACGGTCGCAAGATTAAAACTCAAAGGAATTGACGGGGGCCCGCACAAGCGGTGGAGCATGTGGTTTAATTCGAAGCAACGCGCAGAACCTTACCACCTTTTGACATGCCTGGACCGCCAGAGAGATCTGGCTTTCCCTTCGGGGACTAGGACACAGGTGCTGCATGGCTGTCGTCAGCTCGTGTCGTGAGATGTTGGGTTAAGTCCCGCAACGAGCGCAACCCTCGCCATTAGTTGCCATCATTTAGTTGGGAACTCTAATGGGACTGCCGGTGCTAAGCCGGAGGAAGGTGGGGATGACGTCAAGTCCTCATGGCCCTTACAGGGTGGGCTACACACGTGCTACAATGGCGACTACAGAGGGTTAATCCTTAAAAGTCGTCTCAGTTCGGATTGTCCTCTGCAACTCGAGGGCATGAAGTTGGAATCGCTAGTAATCGCGGATCAGCATGCCGCGGTGAATACGTTCCCGGGCCTTGTACACACCGCCCGTCACACCATGGGAGTTGGTTCTACCCGAAGGCGCTGCGCTAACCGCAAGGGGGCAGGCGACCACGGTAGGGTCAGCGACTGGGGTGAAGTCGTAACAAGGTAACC
+>814974
+GATGAACGCTAGCCGTGTGCCTAATACATGCATGTCGTACGAGAGTACTTGTACTCTAGTGGCGAATGGGTGAGTAACACGTACCTAACCTACTTTTAAGATTGGAATAACTACTGGAAACAGTAGCTAATGCCGAATACGTATTAACTTCGCATGAAGATAATATAAAAGGAGCGTTTGCTCCGCTTAGAAATGGGGGTGCGCCATATTAGTTAGTTGGTAGGGTAATGGCCTACCAAGACGATGATATGTAGCCGGGCTGAGAAGCTGATCGGCCACACTGGGACTGAGATACGGCCCAGACTCCTACGGGAGGCAGCAGTAGGGAATTTTCCGCAATGAGCGAAAGCTTGACGGAGCGACACGGCGTGCAGGATGAAGGTCTTCGGATCGTAAACTGCTGTGGTTAGGGAAGAAAAGCAAAATAGGAAATGATTTTGCCCTGACGGTACCTAACTAGAAAGTGACGGCTAACTATGTGCCAGCAGCCGCGGTAATACATAGGTCACAAGCGTTATCCGGATTTATTGGGCGTAAAGCGTTCGTAGGCGGTTTGTTAAGTCTAGAGTTAAAGCCTGGGGTTCAACCCCAGCCCGCTTTGGATACTGACAAACTAGAGTTACATAGAGGTAAGCGGAATTCTTAGTGAAGCGGTGGAATGCGTAGATATTAGGAAGAACACCAATGGCGAAGGCAGCTTACTGGATGTACACTGACGCTCAGGGACGAAAGCGTGGGGAGCAAACAGGATTAGATACCCTGGTAGTCCACGCCGTAAACGATGATCACTAGCCGCTAGAAAATTTAGTGGCACAGCTAACGCATTAAGTGATCCGCCTGAGTAGTATGCTCGCAAGAGTGAAACTTAAAGGAATTGACGGGGACCCGCACAAGCGGTGGAGCATGTGGTTTAATTTGAAGATACGCGTAGAACCTTACCCACTCTTGACATCTTCCGCAATGCTACAGAGATGTAGTGGAGGTTAACGGAATGACAGATGGTGCATGGTTGTCGTCAGCTCGTGCCGTGAGGTGTTTGGTTAAGTCCAGCAACGAGCGCAACCCTTGTCTTTAGTTACTAATATTAAGTTAAGGACTCTAGAGAGACTGCCAGGGTAACCTGGAGGAAGGTGGGGACGACGTCAAATCATCATGCCTCTTACGAGTGGGGCAACACACGTGCTACAATGGTCGGTACAAAGAGAAGCAAGATGGCGACATGGAGCAAACCTCAAAAAACCGATCTCAGTTCGGATTGTAGTCTGCAACTCGACTACATGAAGTTGGAATCGCTAGTAATCGTAGATCAGCTACGCTACGGTGAATACGTTCTCGGGTCTTGTACACACCGCCCGTCACACCATGGGAGCTGGTAATGCCCGAAGCCGGTTAGTTAACTTCGGAGACGACTGTCTAAGGCAGGACTGGTGACTGGGGTG
+>160832
+GTCGAGCGGCGGACGGGTGAGTAACGGCTGGGAACCTGCCCTGACGCGGGGGATAACCGTTGGAAACGACGGCTAATACCGCATAATGTCTTAGTTCATTACGAGCTGGGACCAAAGGTGGCCTCTACATGTAAGCTATCGCGTTGGGATGGGCCCAGTTAGGATTAGCTAGTTGGTAAGGTAATGGCTTACCAAGGCRACGATCCTTAKCTGGTTTGAGAGGATGATCAGCCACACTGGGACTGAGACACGGCCCAGACTCCTACGGGAGGCAGCAGTGGGGAATATTGCACAATGGGGGAGACCCTGATGCAGCCATGCCGCGTGTGTGAAGAAGGCCTTCGGGTTGTAAAGCACTTTCAGCAGTGAGGAAGGTGGTGTACTTAATAAGTGCATGGCTTGACGTTAGCTGCAGAAGAAGCACCGGCTAACTCCGTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTAATCGGAATTACTGGGCGTAAAGCGCATGCAGGCGGTTTGTTAAGTCAGATGTGAAAGCCCGGGGCTCAACCTCGGAACCGCATTTGAAACTGGCAGGCTAGAGTCTTGTAGAGGGGGGTAGAATTTCAGGTGTAGCGGTGAAATGCGTAGAGATCTGAAGGAATACCAGTGGCGAAGGCGGCCCCCTGGACAAAGACTGACGCTCAGATGCGAAAGCGTGGGTAGCAAACAGGATTAGATACCCTGGTAGTCCACGCCGTAAACGCTGTCTACTTGGAGGTTGAGGTTTAAGACTTTGGCTTTCGGCGCTAACGCATTAAGTAAACCGCCGGGGGAGTACGGCCGCAGGGTTAAAACTCAAATGAATTGACGGGGGCCCGCACAAGCGGTGGAGCATGGGGTTTAATTCGATGCAACGCGAAAAACCTTACCTACTCTTGACATCCAACGAATCCTTTAAAGATGGATGAGTGCCTTCGGAAGCGCTGAAACAGGTGCTGCATGGCTGTCGTCAGCTCGTGTTGTGAAATGTTGGGTTAAGTCCCGCAACGAGCGCAACCCTTATCCTTGTTTGCCAGCACATAATGGTGGGAACTCCAGGGAGACTGCCGGTGATAAACCGGAGGAAGGTGGGGACGACGTCAAGTCATCATGGCCCTTACGAGTAGGGCTACACACGTGCTACAATGGCAGATACAGAGGGCAGCGAAGCTGCGAAGTGGAGCGAATCCCTTAAAGTCTGTCGTAGTCCGGATTGGAGTCTGCAACTCGACTCCATGAAGTCGGAATCGCTAGTAATCGTGGATCAGAATGCCACGGTGAATACGTTCCCGGGCCTTGTACACACCGCCCGTCACACCATGGGAGTGGGCTGCACCAGAAGTAGATAGCTTAACCTTCGGGAGGGCGTTTACCACGGTGTGGTTCATGACTGGGGTGAAGTCGTAACAAGGTAGCCCTAGGGGAACCTGCGGCTG
+>573757
+GCCTAAGGCAGGCAAGTCGAACGATGATCTCCAGCCTGCTGGGGGGATTAGAGGAGAACGGGTGAGTAACACGTGAGTAACCTGCCCTTGACTCTGGGATAAGCCTGGGAAACTGGGTCTAATACTGGATACGACCTTCCCACGCATGTGGTGTTGGTGGAAAGCTTTTGTGGTTTTGGATGGACTCGCGGCCTATCAGCTTGTTGGTGGGGTAATGGCCTACCAAGGCGACGACGGGTAGCCGGCCTGAGAGGGTGGACGGCCACACTGGGACTGAGACACGGCCCAGACTCCTACGGGAGGCAGCAGTGGGGAATATTGCACAATGGGCGCAAGCCTGATGCAGCGACGCCGCGTGAGGGATGAAGGCCTTCGGGTTGTAAACCTCTTTCAGTAGGGAAGAAGCGAAAGTGACGGTACCTGCAGAAGAAGCGCCGGCTAACTACGTGCCAGCAGCCGCGGTAATACGTAGGGCGCAAGCGTTATCCGGAATTATTGGGCGTAAAGAGCTCGTAGGCGGTTTGTCGCGTCTGCCGTGAAAGTCCGGGGCTTAACTCCGGATCTGCGGTGGGTACGGGCAGACTTGAGTGATGTAGGGGAGACTGGAATTCCTGGTGTAGCGGTGAAATGCGCAGATATCAGGAGGAACACCGATGGCGAAGGCAGGTCTCTGGGCATTAACTGACGCTGAGGAGCGAAAGCATGGGGAGCGAACAGGATTAGATACCCTGGTAGTCCACACCGTAAACGTTGGGCGCTAGGTGTGGGGCCTATTCCATGGGTTCCGTGCCGCAGCTAACGCATTAAGCGCCCCGCCTGGGGAGTACGGCCGCAAGGCTAAAACTCAAAGGAATTGACGGGGGCCCGCACAAGCGGCGGAGCATGCGGATTAATTCGATGCAACGCGAAGAACCTTACCTGGGTTTGACATATGCCGGAAAGCCGTAGAGATACGGCCCCTTTTTGTCGGTATACAGGTGGTGCATGGCTGTCGTCAGCTCGTGTCGTGAGATGTTGGGTTAAGTCCCGCAACGAGCGCAACCCTCGTCCTATGTTGCCAGCACGCCCGTAGGGTGGTGGGGACTCATAGGAGGCTGCCGGGGTCAACTCGGAGGAAGGTGGGGATGACGTCAAGTCATCATGCCCCTTATGTCCAGGGCTTCACGCATGCTACAATGGCCGGTACAAAGGGCTGCGATCCCGTGAGGGGGAGCGAATCCCAAAAAGCCGGTCTCAGTTCGGATTGGGGTCTGCAACTCGACCCCATGAAGTCGGAGTCGCTAGTAATCGCAGATCAGCAACGCTGCGGTGAATACGTTCCCGGGCCTTGCACACACCGCCCGTCAC
+>579954
+TGGCGGCGTGGATAAGACATGCAAGTCGAACGGGATATTGTTTGTAGCAATACAAGCGATGTCTAGTGGCGTAAGGGTGCGTAACACGTGGGGAATCTGCCGAGAAGTGGGGGATAGCTCGCCGAAAGGCGAATTAATACCGCATGTGGTTAGGGAAGACATCTTCCCGACACTAAAGCCGGGGCAACCTGGCGCTTCTTGATGACCCCGCGGCCTATCAGCTAGTCGGTGAGGTAACGGCTCACCAAGGCTATGACGGGTAGCTGGTCTGAGAGGACGACCAGCCACACTGGAACTGAGACACGGTCCAGACACCTACGGGTGGCAGCAGTCGAGAATTTTTCTCAATGGGGGAAACCCTGAAGGAGCGACGCCGCGTGGAGGATGAAGGTCTTCGGATTGTAAACTCCTGTCATGCGGGAACAATTGTCACCGATTAACTGTCGGGGGCTTGATAGTACCAGAAGAGGAAGAGACGGCTAACTCTGTGCCAGCAGCCGCGGTAATACAGAGGTCTCAAGCGTTGTTCGGATTCATTGGGCGTAAAGGGTGCGTAGGTGGCGGGGTAAGTCAGGTGTGAAATCTCGGAGCTCAACTCCGAAACTGCACTTGATACTGCCTTGCTCGAGTACTGGAGAGGAGATTGGAATTTACGGTGTAGCAGTGAAATGCGTAGATATCGTAAGGAAGACCAGTGGCGAAGGCGAATCTCTGGACAGTTACTGACACTGAGGCACGAAGGCCAGGGGAGCAAACAGGATTAGATACCCTGGTAGTCCTGGCAGTAAACGGTGCGCGTTTGGTGTGGGAGGATTCGACCCCTTCTGTGCCGGAGCTAACGCGTTAAACGCGCCGCCTGGGGAGTACGGTCGCAAGATTAAAACTCAAAGAAATTGACGGGGGCCCGCACAAGCGGTGGAGTATGTGGCTTAATTCGATGCAACGCGAAGAACCTTACCTAGCCTTGACATGCATCTCTAAGTCGGTGAAAGCCGGCGACTATAGCAATATAGAATTTGCACAGGTGCTGCATGGCTGTCGTCAGCTCGTGTCGTGAGATGTTGGGTTAAGTCCCGCAACGAGCGCAACCCCTGTGAACTGTTGCCACCGATCTTCGGATCGAGCACTCTGTTCAGACTGCCCTGTGAAACGGGGAGGAAGGTGGGGATGACGTCAAGTCAGCATGGCCCTTACGGCTAGGGCTGCACACGTACTACAATGCTCAGTACAGAATGAACCGAAACCGCGAGGTGGAGGAAATCCATAAAACTGAGCCCAATTCGGATTGGAGGCTGCAACTCGCCTCCATGAAGCCGGAATCGCTAGTAATGGCGTATCAGCTACGACGCCGTGAATACGTTCCCGGGCCTTGTACACACCG
+>311922
+GATTGAACGCTGGCGGCAGGCCTAACACATGCAAGTCGAACGGTAACATGAAGTGCTTGCACTTTGATGACGAGTGGCGGACGGGTGAGTAATGCTTGGGAATTTGCCTTTGCGCGGGGGATAACCATTGGAAACGATGGCTAATACCGCATAATGTCTACGGACCAAAGGGGGCTTAGGCTCCCACGTGAAGAGAAGCCCAAGTGAGATTAGCTAGTTGGTGGGGTAAAGGCTCACCAAGGCGACGATCTCTAGCTGTTCCGAGAGGAAGATCAGCCACACTGGGACTGAGACACGGCCCAGACTCCTACGGGAGGCAGCAGTGGGGAATATTGCGCAATGGGGGGAACCCTGACGCAGCCATGCCGCGTGTGTGAAGAAGGCCTTCGGGTTGTAAAGCACTTTCAGTTATGAGGAAAGGTTGTTGGTTAATACCCAGCAGCTGTGACGTTAATAACAGAAGAAGCACCGGCTAACTCCGTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTAATCGGAATTACTGGGCGTAAAGCGCACGCAGGCGGTTAATTAAGCTAGAAGTGAAAGCCCTGCGCTCAACGTGGGAAGGCCTTTTAGAACTGGTTAACTAGAGTATTGGAGAGGGGAGTGGAATTCCAGGTGTAGCGGTGAAATGCGTAGATATCTGGAGGAACACCGGTGGCGAAGGCGACTCTCTGGCCCAAATACTGACGCTCATGTGCGAAAGTGTGGGTAGCGAACAGGATTAGATACCCTGGTAGTCCACACCGTAAACGATGTCTACTAGCTGTGTGCGAATGTATATTTGTGCGTAGCGCAGCCAACGCGATAAGTAGACCGCCTGGGGAGTACGGCCGCAAGGTTAAAACTCAAATGAATTGACGGGGGCCCGCACAAGCGGTGGAGCATGTGGTTTAATTCGATGCAACGCGAAGAACCTTACCTACACTTGACATGCAGAGAACTTTCTAGAGATAGATTGGTGCCTTCGGGAACTCTGACACAGGTGCTGCATGGCTGTCGTCAGCTCGTGTCGTGAGATGTTGGGTTAAGTCCCGCAACGAGCGCAACCCTTGTCCTTATTTGCCAGCATTAAGTTGGGGACTTTAAGGAGACTGCCGGTGACAAACCGGAGGAAGGTGGGGACGACGTCAAGTCATCATGGCCCTTACGTGTAGGGCTACACACGTGCTACAATGGTAAGTACAGAGGGAAGCGAACTTGTGAGAGTAAGCGGACCCCAAAAAGCTTATCGTAGTCCGGATTGGAGTCTGCAACTCGACTCCATGAAGTCGGAATCGCTAGTAATCGCAGGTCAGCATACTGCGGTGAATACGTTCCCGGGCCTTGTACACACCGCCCGTCACACCATGGGAGTGGGATGCAAAAGAAGTAGGTAGCATAACCTTTAGGAGTGCGCTTACCACTTTGTGTTTCATGACTGGGGT
+>4370324
+TCAGGATGAACGCTAGCGACAGGCCTAACACATGCAAGTCGAGGGGTAACATTGGTAGCTTGCTACCAGATGACGACCGGCGCACGGGTGAGTAACGCGTATGCAACCTTCCTTTAACAGGAGAATAGCCCCCGGAAACGGGGATTAATGCTCCATGGCACTCTAATTTCGCATGGAATAAGAGTTAAAGTTCCGACGGTTAAAGATGGGCATGCGTGACATTAGCCAGTTGGCGGGGTAACGGCCCACCAAAGCAACGATGTCTAGGGGTTCTGAGAGGAAGGTCCCCCACACTGGTACTGAGACACGGACCAGACTCCTACGGGAGGCAGCAGTGAGGAATATTGGTCAATGGACGCAAGTCTGAACCAGCCATGTCGCGTGCAGGATGACTGCCCTATGGGTTGTAAACTGCTTTTGTACGGGAAGAAATGTACTTACGAGTAAGTATTTGCCGGTACCGTACGAATAAGCATCGGCTAACTCCGTGCCAGCAGCCGCGGTAATACGGAGGATGCGAGCGTTATCCGGATTTATTGGGTTTAAAGGGTGCGTAGGCGGAATGGTAAGTCAGTGGTGAAATCCTGCAGCTCAACTGTAGAGTTGCCATTGATACTGTCATTCTTGAGTATAGATGAGGTAGGCGGAATGAGTAGTGTAGCGGTGAAATGCATAGATATTACTCAGAACACCAATTGCGAAGGCAGCTTACTAAACTATAACTGACGCTGAAGCACGAAAGCGTGGGTATCAAACAGGATTAGATACCCTGGTAGTCCACGCCGTAAACGATGATTACTGGTTGTTTGCAATACACCGCAAGCGACTGAGCGAAAGCATTAAGTAATCCACCTGGGGAGTACGTCGGCAACGATGAAACTCAAAGGAATTGACGGGGGCCCGCACAAGCGGTGGAACATGTGGTTTAATTCGATGATACGCGAGGAACCTTACCTGGGTTTAAATGGGAAGTGACAGGGGTAGAAATACCTTTTTCTTCGGACACTTTTCAAGGTGCTGCATGGTTGTCGTCAGCTCGTGCCGTGAGGTGTCGGGTTAAGTCCCATAACGAGCGCAACCCCTGTTGTTAGTTACCAGCATGTAAAGATGGGGACTCTAACAAGACTGCCGGTGTAAACCGCGAGGAAGGTGGGGATGACGTCAAATCAGCACGGCCCTTACATCCAGGGCTACACACGTGTTACAATGGCAGGTACAAAGGGCAGCTACACAGCGATGTGATGCTAATCTCGAAAACCTGTCCCAGTTCGGATTGAAGTCTGCAACCCGACTTCATGAAGCTGGAATCGCTAGTAATCGCGCATCAGCCATGGCGCGGTGAATACGTTCCCGGGCCTTGTACACTCCGCCCGTCAAGCCATGGAAGCCGGGAGTACCTGAAG
+>646991
+AGTTTGATCTTGGCTCAGGATGAACGCTAGCGGCAGGCCTAATACATGCAAGTCGTGGGGCATCAGCGCCTTCGGGCGGCTGGCGACCGGCGCACGGGTGCGTAACGCGTATGCAACCTGCCCACAACAGGGGGACAGCCTTCGGAAACGAGGATTAATACCCCATGATACAGGGGTACCGCATGGTGCCTTTCGTCAAAGGTTTCGGCCGGTTGTGGATGGGCATGCGTCCCATTAGCTAGTAGGCGGGGTAACGGCCCACCTAGGCTATGATGGGTAGGGGTTCTGAGAGGACGATCCCCCACACTGGTACTGAGATACGGACCAGACTCCTACGGGAGGCAGCAGTAGGGAATATTGGGCAATGGGCGGAAGCCTGACCCAGCCATGCCGCGTGCAGGACGAAGGCCCTCGGGTCGTAAACTGCTTTTATACGGGAAGAACTGCGTCCTGCGGGACGCGCTGACGGTACCGTACGAATAAGCACCGGCTAACTCCGTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTGTCCGGATTTATTGGGTTTAAAGGGTACGTAGGCGGTGTATTAAGTCAGTGGTGAAAGCCTGCGGCTCAACCGTAGGAGTGCCATTGATACTGGTATACTTGAGTGTTGTAAGGGTGGGCGGAATTCCGCATGTAGCGGTGAAATGCATAGATATGCGGAGGAACACCGAGAGCGAAGGCAGCTCACTAGGCACGACTGACGCTGAGGTACGAAAGCGTGGGGAGCGAACAGGATTAGATACCCTGGTAGTCCACGCCGTAAACGATGGTAACTAGGTGTGTGCGACACAGAGTGCGCGCCCAAGCGAAAGCGATAAGTTACCCACCTGGGGAGTACGCTCGCAAGAGTGAAACTCAAAGGAATTGACGGGGGTCCGCACAAGCGGTGGAGCATGTGGTTTAATTCGATGATACGCGAGGAACCTTACCTGGGCTCGAATGGCCTATGACAGGCCCAGAGATGGGCCCTTCCTCGGACATAGGTCAAGGTGCTGCATGGCTGTCGTCAGCTCGTGCCGTGAGGTGTTGGGTTAAGTCCCGCAACGAGCGCAACCCTTGCCCCTAGTTGCCATCAGGTAAAGCTGGGGACTCTAGGGGGACTGCCTGCGCAAGCAGAGAGGAAGGAGGGGACGATGTCAAGTCATCATGGCCCTTACGCCCAGGGCTACACACGTGCTACAATGGCGCATACAGAGGGTAGCCACCTGGCGACAGGGCGCCAATCTCAAAAAGTGCGTCTCAGTTCGGATCGGGGCCTGCAACTCGGCCCCGTGAAGTCGGAATCGCTAGTAATCGCAGATCAGCCATGCTGCGGTGAATACGTTCCCGGGCCTTGTACACACCGCCCGTCAAGCCATGGAAGCCGGGGGCACCTGAAGTCGGGGGTAACAACCCGCCTAGGGTGAAACTGGTAACTGGGGCTAAGTCGTAACAAGGTAACCGTA
+>510574
+GAGTTTGATCCTGGCTCAGATTGAACGCTGGCGGAATGCTTTACACATGCAAGTCGAGCGGCAGCGCGGGGGCAACCCTGGCGGCGAGCGGCGAACGGGTGAGTAACACATCGGAACGTACCCAATTGAGGGGGATAGCCCGGCGAAAGCCGGATTAATACCGCATAAGTCCTGAGGGAGAAAGCGGGGGACCGCAAGGCCTCGCGCGATTGGAGCGGCCGATGTCGGATTAGCTAGTTGGTGGGGTAAAGGCTCACCAAGGCGACGATCCGTAGCTGGTCTGAGAGGATGATCAGCCACACTGGGACTGAGACACGGCCCAGACTCCTACGGGAGGCAGCAGTGGGGAATTTTGGACAATGGGCGCAAGCCTGATCCAGCCATTCCGCGTGAGTGAAGAAGGCCTTCGGGTTGTAAAGCTCTTTCGGACGGAAAGAAATCGCCCGGGTAAATAATCCGGGTGGATGACGGTACCGTAAGAAGAAGCACCGGCTAACTACGTGCCAGCAGCCGCGGTAATACGTAGGGTGCGAGCGTTAATCGGAATTACTGGGCGTAAAGCGTGCGCAGGCGGCTACATAAGACAGGTGTGAAATCCCCGGGCTCAACCTGGGAATGGCGCTTGTGACTGTGTGGCTTGAGTTCGGCAGAGGGGGGTGGAATTCCACGTGTAGCAGTGAAATGCGTAGAGATGTGGAGGAACACCGATGGCGAAGGCAGCCCCCCTGGGCCGTGACTGACGCTTATGCACGAAAGCGTGGGGAGCAAACAGGATTAGATACCCTGGTAGTCCACGCCCTAAACGATGTCGACTAGGTGTTGGGGAAGGAGACTTCTTTAGTACCGTAGCTAACGCGTGAAGTCGACCGCCTGGGGAGTACGGCCGCAAGGTTAAAACTCAAAGGAATTGACGGGGACCCGCACAAGCGGTGGATGATGTGGATTAATTCGATGCAACGCGAAAAACCTTACCTACCCTTGACATGCCAGGAACCTTGCTGAGAGGTGAGGGTGCCCGAAAGGGAACCTGGACACAGGTGCTGCATGGCTGTCGTCAGCTCGTGTCGTGAGATGTTGGGTTAAGTCCCGCAACGAGCGCAACCCTTGTCATTAATTGCCATCATTGAGTTGGGCACTTTAATGAGACTGCCGGTGACAAACCGGAGGAAGGTGGGGATGACGTCAAGTCCTCATGGCCCTTATGGGTAGGGCTTCACACGTCATACAATGGCGCATACAGAGGGTTGCCAACCCGCGAGGGGGAGCGAATCCCAGAAAATGCGTCGTAGTCCGGATCGCAGTCTGCAACTCGACTGCGTGAAGTCGGAATCGCTAGTAATCGCGGATCAGCATGTCGCGGTGAATACGTTCCCGGGTCTTGTACACACCGCCCGTCACACCATGGGAGTGGGTTCCACCAGAAGTAGGTAGCTTAACCGCAAGGAGGGCGCTTACCACGGTGAGATTCATGACTGGGGTGAAGTCGTAACAAGGTAACC
+>769294
+AGAGTTTGATCCTGGCTCAGGACGAACGCTGGCGGCGTGCTTAACACATGCAAGTCAAGGGGAAAGTTTTCTTCGGAGAATTAGTATACTGGCGCACGGGTGAGTAATGTATAAGTAATCTACCTATAGGAAAGGAATAACTCTAAGAAATTGGGGCTAATACCATATAATGCAGCGGCACCGCATGGTGATGTTGTTAAAGTAATTTATTACGCCTATAGATGAGCTTGTATTCGATTAGCTTGTTGGTAAGGTAACGGCTTACCAAGGCGACGATCGATAGCTGGTCTGAGAGGATGATCAGCCACACTGGAACTGAGACACGGTCCAGACTCCTACGGGAGGCAGCAGTGAGGAATATTGGGCAATGGACGAAAGTCTGACCCAGCAACGCCGCGTGGAGGATGAAGGTCGTAAGATCGTAAACTCCTTTTTTGGGGGAAGAAAAAACAGGTTTGTAGCCTGTATTGACTGTACCCTAAGAATAAGCCCCGGCTAACTACGTGCCAGCAGCCGCGGTAATACGTAGGGGGCAAGCGTTGTCCGGATTTACTGGGTATAAAGGGCTCGCAGGCGGGTTTGTAAGTCAGAGGTGAAATCCTACAGCTTAACTGTAGAACTGCCTTTGAAACTGCAAGTCTTGAGATCGGAAGAGAGAGATGGAATTCCAGGTGTAGTAGTGAAATACGTAGATATCTGGAAGAACACCAACGGCGAAGGCAGTCTCTTGGTCCGTATCTGACGCTGAGGAGCGAAAGCGTGGGGAGCAAACAGGATTAGATACCCTGGTAGTCCACGCCGTAAACGATGAATACTAGGTGTCGGATTCTATGAATTCGGTGCCGCAGCTAATGCATTAAGTATTCCACCTGGGGAGTACGATCGCAAGGTTGAAACTCAAAGGAATTGACGGGGGCCCGCACAAGCAGTGGAGCATGTGGTTTAATTCGATGCAACGCGAAGAACCTTACCTAGGCTTGAAATGCTGTGGACCGCTTGTGAAAGCAAGCTTCTCTTCGGAGCCGCAGTACAGGTGCTGCATGGCTGTCGTCAGCTCGTGCCGTGAGGTGTTGGGTTAAGTCCCGCAACGAGCGCAACCCCTGCCATTAGTTGCCATCAGGTTAAGCTGGGCACTCTAATGGGACTGCCTACGCAAGTAGTGAGGAAGGTGGGGATGACGTCAAGTCAGCATGGCCCTTACGCCTAGGGCTACACACGTGCTACAATGGATACTACAATGGGTTGCCAAGCCGCGAGGTGGAGCCAATCCCTTAAAAGTATCCTCAGTTCGGATTGGAGTCTGCAACTCGACTCCATGAAGCCGGAATTGCTAGTAATCGCGTATCAGCATGACGCGGTGAATACGTTCCCGGGCCTTGTACACACCGCCCGTCAAGCCATGGAAGCCGGGGGTACCCAAAGTCAGCGACCCAACCGCAAGGAGGGAGCTGCCTAAGGTAAAACTAGTGACTGGGGCTAAGTCGTAACAAGGTAACC
+"""
+
+# Reference database for single chimera sequence (ref)
+uchime_single_ref_db = """>646991
+AGTTTGATCTTGGCTCAGGATGAACGCTAGCGGCAGGCCTAATACATGCAAGTCGTGGGGCATCAGCGCCTTCGGGCGGCTGGCGACCGGCGCACGGGTGCGTAACGCGTATGCAACCTGCCCACAACAGGGGGACAGCCTTCGGAAACGAGGATTAATACCCCATGATACAGGGGTACCGCATGGTGCCTTTCGTCAAAGGTTTCGGCCGGTTGTGGATGGGCATGCGTCCCATTAGCTAGTAGGCGGGGTAACGGCCCACCTAGGCTATGATGGGTAGGGGTTCTGAGAGGACGATCCCCCACACTGGTACTGAGATACGGACCAGACTCCTACGGGAGGCAGCAGTAGGGAATATTGGGCAATGGGCGGAAGCCTGACCCAGCCATGCCGCGTGCAGGACGAAGGCCCTCGGGTCGTAAACTGCTTTTATACGGGAAGAACTGCGTCCTGCGGGACGCGCTGACGGTACCGTACGAATAAGCACCGGCTAACTCCGTGCCAGCAGCCGCGGTAATACGGAGGGTGCGAGCGTTGTCCGGATTTATTGGGTTTAAAGGGTACGTAGGCGGTGTATTAAGTCAGTGGTGAAAGCCTGCGGCTCAACCGTAGGAGTGCCATTGATACTGGTATACTTGAGTGTTGTAAGGGTGGGCGGAATTCCGCATGTAGCGGTGAAATGCATAGATATGCGGAGGAACACCGAGAGCGAAGGCAGCTCACTAGGCACGACTGACGCTGAGGTACGAAAGCGTGGGGAGCGAACAGGATTAGATACCCTGGTAGTCCACGCCGTAAACGATGGTAACTAGGTGTGTGCGACACAGAGTGCGCGCCCAAGCGAAAGCGATAAGTTACCCACCTGGGGAGTACGCTCGCAAGAGTGAAACTCAAAGGAATTGACGGGGGTCCGCACAAGCGGTGGAGCATGTGGTTTAATTCGATGATACGCGAGGAACCTTACCTGGGCTCGAATGGCCTATGACAGGCCCAGAGATGGGCCCTTCCTCGGACATAGGTCAAGGTGCTGCATGGCTGTCGTCAGCTCGTGCCGTGAGGTGTTGGGTTAAGTCCCGCAACGAGCGCAACCCTTGCCCCTAGTTGCCATCAGGTAAAGCTGGGGACTCTAGGGGGACTGCCTGCGCAAGCAGAGAGGAAGGAGGGGACGATGTCAAGTCATCATGGCCCTTACGCCCAGGGCTACACACGTGCTACAATGGCGCATACAGAGGGTAGCCACCTGGCGACAGGGCGCCAATCTCAAAAAGTGCGTCTCAGTTCGGATCGGGGCCTGCAACTCGGCCCCGTGAAGTCGGAATCGCTAGTAATCGCAGATCAGCCATGCTGCGGTGAATACGTTCCCGGGCCTTGTACACACCGCCCGTCAAGCCATGGAAGCCGGGGGCACCTGAAGTCGGGGGTAACAACCCGCCTAGGGTGAAACTGGTAACTGGGGCTAAGTCGTAACAAGGTAACCGTA
+>4370324
+TCAGGATGAACGCTAGCGACAGGCCTAACACATGCAAGTCGAGGGGTAACATTGGTAGCTTGCTACCAGATGACGACCGGCGCACGGGTGAGTAACGCGTATGCAACCTTCCTTTAACAGGAGAATAGCCCCCGGAAACGGGGATTAATGCTCCATGGCACTCTAATTTCGCATGGAATAAGAGTTAAAGTTCCGACGGTTAAAGATGGGCATGCGTGACATTAGCCAGTTGGCGGGGTAACGGCCCACCAAAGCAACGATGTCTAGGGGTTCTGAGAGGAAGGTCCCCCACACTGGTACTGAGACACGGACCAGACTCCTACGGGAGGCAGCAGTGAGGAATATTGGTCAATGGACGCAAGTCTGAACCAGCCATGTCGCGTGCAGGATGACTGCCCTATGGGTTGTAAACTGCTTTTGTACGGGAAGAAATGTACTTACGAGTAAGTATTTGCCGGTACCGTACGAATAAGCATCGGCTAACTCCGTGCCAGCAGCCGCGGTAATACGGAGGATGCGAGCGTTATCCGGATTTATTGGGTTTAAAGGGTGCGTAGGCGGAATGGTAAGTCAGTGGTGAAATCCTGCAGCTCAACTGTAGAGTTGCCATTGATACTGTCATTCTTGAGTATAGATGAGGTAGGCGGAATGAGTAGTGTAGCGGTGAAATGCATAGATATTACTCAGAACACCAATTGCGAAGGCAGCTTACTAAACTATAACTGACGCTGAAGCACGAAAGCGTGGGTATCAAACAGGATTAGATACCCTGGTAGTCCACGCCGTAAACGATGATTACTGGTTGTTTGCAATACACCGCAAGCGACTGAGCGAAAGCATTAAGTAATCCACCTGGGGAGTACGTCGGCAACGATGAAACTCAAAGGAATTGACGGGGGCCCGCACAAGCGGTGGAACATGTGGTTTAATTCGATGATACGCGAGGAACCTTACCTGGGTTTAAATGGGAAGTGACAGGGGTAGAAATACCTTTTTCTTCGGACACTTTTCAAGGTGCTGCATGGTTGTCGTCAGCTCGTGCCGTGAGGTGTCGGGTTAAGTCCCATAACGAGCGCAACCCCTGTTGTTAGTTACCAGCATGTAAAGATGGGGACTCTAACAAGACTGCCGGTGTAAACCGCGAGGAAGGTGGGGATGACGTCAAATCAGCACGGCCCTTACATCCAGGGCTACACACGTGTTACAATGGCAGGTACAAAGGGCAGCTACACAGCGATGTGATGCTAATCTCGAAAACCTGTCCCAGTTCGGATTGAAGTCTGCAACCCGACTTCATGAAGCTGGAATCGCTAGTAATCGCGCATCAGCCATGGCGCGGTGAATACGTTCCCGGGCCTTGTACACTCCGCCCGTCAAGCCATGGAAGCCGGGAGTACCTGAAG
+"""
+
+# 3-way alignment for single chimeric sequence against reference
+# database using UCHIME
+single_chimera_ref_aln = """
+------------------------------------------------------------------------
+Query   (  150 nt) 251;size=2;
+ParentA ( 1403 nt) 4370324
+ParentB ( 1480 nt) 646991
+
+A     1 tcaggatgaacgctagcgacaggcctaacacatgcaagtcgaggggtaacattggtagcttgctaccagatgacgaccgg 80
+Q     1 -------------------------------------------------------------------------------- 0
+B     1 agtttgatcttggctcaggatgaacgctagcggcaggcctaatacatgcaagtcgtggggcatcagcgccttcgggcggc 80
+Diffs                                                                                   
+Votes                                                                                   
+Model   AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+
+A    81 cgcacgggtgagtaacgcgtatgcaaccttcctttaacaggagaatagcccccggaaacggggattaatgctccatggca 160
+Q     1 -------------------------------------------------------------------------------- 0
+B    81 tggcgaccggcgcacgggtgcgtaacgcgtatgcaacctgcccacaacagggggacagccttcggaaacgaggattaata 160
+Diffs                                                                                   
+Votes                                                                                   
+Model   AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+
+A   161 ctctaatttcgcatggaataagagttaaagttccgacggttaaagatgggcatgcgtgacattagccagttggcggggta 240
+Q     1 -------------------------------------------------------------------------------- 0
+B   161 ccccatgatacaggggtaccgcatggtgcctttcgtcaaaggtttcggccggttgtggatgggcatgcgtcccattagct 240
+Diffs                                                                                   
+Votes                                                                                   
+Model   AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+
+A   241 acggcccaccaaagcaacgatgtctaggggttctgagaggaaggtcccccacactggtactgagacacggaccagactcc 320
+Q     1 -------------------------------------------------------------------------------- 0
+B   241 agtaggcggggtaacggcccacctaggctatgatgggtaggggttctgagaggacgatcccccacactggtactgagata 320
+Diffs                                                                                   
+Votes                                                                                   
+Model   AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+
+A   321 tacgggaggcagcagtgaggaatattggtcaatggacgcaagtctgaaccagccatgtcgcgtgcaggatgactgcccta 400
+Q     1 -------------------------------------------------------------------------------- 0
+B   321 cggaccagactcctacgggaggcagcagtagggaatattgggcaatgggcggaagcctgacccagccatgccgcgtgcag 400
+Diffs                                                                                   
+Votes                                                                                   
+Model   AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+
+A   401 tgggttgtaaactgcttttgtacgggaagaaatgtacttacgagtaagtatttgccggtaccgtacgaataagcatcggc 480
+Q     1 -------------------------------------------------------------------------------- 0
+B   401 gacgaaggccctcgggtcgtaaactgcttttatacgggaagaactgcgtcctgcgggacgcgctgacggtaccgtacgaa 480
+Diffs                                                                                   
+Votes                                                                                   
+Model   AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+
+A   481 taactcc-----------GTGCCAGCAGCCGCGGTAATACGGAGGATGCGAGCGTTATCCGGATTTATTGGGTTTAAAGG 549
+Q     1 ------------------GTGCCAGCAGCCGCGGTAATACGGAGGATGCGAGCGTTATCCGGATTTATTGGGTTTAAAGG 62
+B   481 taagcaccggctaactccGTGCCAGCAGCCGCGGTAATACGGAGGgTGCGAGCGTTgTCCGGATTTATTGGGTTTAAAGG 560
+Diffs                                                A          A                       
+Votes                                                +          +                       
+Model   AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+
+A   550 GTGCGTAGGCGGAATGGTAAGTCAGTGGTGAAATCCTGCAGCTCAACTGTAGAGTTGCCATTGATACTGtcATtCTTGAG 629
+Q    63 GTGCGTAGGCGGAATGGTAAGTCAGTGGTGAAATCCTGCAGCTCAACTGTAGAGTTGCCATTGATACTGGTATACTTGAG 142
+B   561 GTaCGTAGGCGGtgTatTAAGTCAGTGGTGAAAgCCTGCgGCTCAACcGTAGgagTGCCATTGATACTGGTATACTTGAG 640
+Diffs     A         AA AA                A     A       A    AAA              BB  B      
+Votes     +         ++ ++                +     +       +    +++              ++  +      
+Model   AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxxxxxxxxxxxxxxBBBBBBBBBBB
+
+A   630 TaTaGatgaggtaggcggaatgagtagtgtagcggtgaaatgcatagatattactcagaacaccaattgcgaaggcagct 709
+Q   143 TGTTGTAA------------------------------------------------------------------------ 150
+B   641 TGTTGTAAgggtgggcggaattccgcatgtagcggtgaaatgcatagatatgcggaggaacaccgagagcgaaggcagct 720
+Diffs    B B BBB                                                                        
+Votes    + + ++                                                                         
+Model   BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB
+
+A   710 tactaaactataactgacgctgaagcacgaaagcgtgggtatcaaacaggattagataccctggtagtccacgccgtaaa 789
+Q   151 -------------------------------------------------------------------------------- 150
+B   721 cactaggcacgactgacgctgaggtacgaaagcgtggggagcgaacaggattagataccctggtagtccacgccgtaaac 800
+Diffs                                                                                   
+Votes                                                                                   
+Model   BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB
+
+A   790 cgatgattactggttgtttgcaatacaccgcaagcgactgagcgaaagcattaagtaatccacctggggagtacgtcggc 869
+Q   151 -------------------------------------------------------------------------------- 150
+B   801 gatggtaactaggtgtgtgcgacacagagtgcgcgcccaagcgaaagcgataagttacccacctggggagtacgctcgca 880
+Diffs                                                                                   
+Votes                                                                                   
+Model   BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB
+
+A   870 aacgatgaaactcaaaggaattgacgggggcccgcacaagcggtggaacatgtggtttaattcgatgatacgcgaggaac 949
+Q   151 -------------------------------------------------------------------------------- 150
+B   881 agagtgaaactcaaaggaattgacgggggtccgcacaagcggtggagcatgtggtttaattcgatgatacgcgaggaacc 960
+Diffs                                                                                   
+Votes                                                                                   
+Model   BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB
+
+A   950 cttacctgggtttaaatgggaagtgacaggggtagaaatacctttttcttcggacacttttcaaggtgctgcatggttgt 1029
+Q   151 -------------------------------------------------------------------------------- 150
+B   961 ttacctgggctcgaatggcctatgacaggcccagagatgggcccttcctcggacataggtcaaggtgctgcatggctgtc 1040
+Diffs                                                                                   
+Votes                                                                                   
+Model   BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB
+
+A  1030 cgtcagctcgtgccgtgaggtgtcgggttaagtcccataacgagcgcaacccctgttgttagttaccagcatgtaaagat 1109
+Q   151 -------------------------------------------------------------------------------- 150
+B  1041 gtcagctcgtgccgtgaggtgttgggttaagtcccgcaacgagcgcaacccttgcccctagttgccatcaggtaaagctg 1120
+Diffs                                                                                   
+Votes                                                                                   
+Model   BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB
+
+A  1110 ggggactctaacaagactgccggtgtaaaccgcgaggaaggtggggatgacgtcaaatcagcacggcccttacatccagg 1189
+Q   151 -------------------------------------------------------------------------------- 150
+B  1121 gggactctagggggactgcctgcgcaagcagagaggaaggaggggacgatgtcaagtcatcatggcccttacgcccaggg 1200
+Diffs                                                                                   
+Votes                                                                                   
+Model   BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB
+
+A  1190 gctacacacgtgttacaatggcaggtacaaagggcagctacacagcgatgtgatgctaatctcgaaaacctgtcccagtt 1269
+Q   151 -------------------------------------------------------------------------------- 150
+B  1201 ctacacacgtgctacaatggcgcatacagagggtagccacctggcgacagggcgccaatctcaaaaagtgcgtctcagtt 1280
+Diffs                                                                                   
+Votes                                                                                   
+Model   BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB
+
+A  1270 cggattgaagtctgcaacccgacttcatgaagctggaatcgctagtaatcgcgcatcagccatggcgcggtgaatacgtt 1349
+Q   151 -------------------------------------------------------------------------------- 150
+B  1281 cggatcggggcctgcaactcggccccgtgaagtcggaatcgctagtaatcgcagatcagccatgctgcggtgaatacgtt 1360
+Diffs                                                                                   
+Votes                                                                                   
+Model   BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB
+
+A  1350 cccgggccttgtacactccgcccgtcaagccatggaagccgggagtacctgaag-------------------------- 1403
+Q   151 -------------------------------------------------------------------------------- 150
+B  1361 cccgggccttgtacacaccgcccgtcaagccatggaagccgggggcacctgaagtcgggggtaacaacccgcctagggtg 1440
+Diffs                                                                                   
+Votes                                                                                   
+Model   BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB
+
+A  1404 ---------------------------------------- 1403
+Q   151 ---------------------------------------- 150
+B  1441 aaactggtaactggggctaagtcgtaacaaggtaaccgta 1480
+Diffs                                           
+Votes                                           
+Model   BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB
+
+Ids.  QA 95.3%, QB 91.2%, AB 86.5%, QModel 100.0%, Div. +5.0%
+Diffs Left 13: N 0, A 0, Y 13 (100.0%); Right 7: N 0, A 0, Y 7 (100.0%), Score 0.7254
+"""
+
+# UCHIME tabular output for single chimeric sequence
+single_chimera_ref_tab = """0.7254\t251;size=2;\t4370324\t646991\t4370324\t100.0\t95.3\t91.2\t86.5\t95.3\t13\t0\t0\t7\t0\t0\t4.7\tY
+"""
+
+
+if __name__ == '__main__':
+    main()

--- a/bfillings/tests/test_vsearch.py
+++ b/bfillings/tests/test_vsearch.py
@@ -8,8 +8,8 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 # -----------------------------------------------------------------------------
 """
-Unit tests for the VSEARCH version 1.0.7 Application controller
-===============================================================
+Unit tests for the VSEARCH version 1.0.10 Application controller
+================================================================
 """
 
 
@@ -30,7 +30,7 @@ from bfillings.vsearch import (vsearch_dereplicate_exact_seqs,
 
 # Test class and cases
 class VsearchTests(TestCase):
-    """ Tests for VSEARCH version 1.0.7 functionality """
+    """ Tests for VSEARCH version 1.0.10 functionality """
 
     def setUp(self):
         self.output_dir = mkdtemp()

--- a/bfillings/tests/test_vsearch.py
+++ b/bfillings/tests/test_vsearch.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 # Copyright (c) 2015--, biocore development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
 # The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 """
 Unit tests for the VSEARCH version 1.0.7 Application controller
 ===============================================================
@@ -14,9 +14,8 @@ Unit tests for the VSEARCH version 1.0.7 Application controller
 
 
 from unittest import TestCase, main
-import re
 from os import close
-from os.path import abspath, exists, join, dirname
+from os.path import exists, join, dirname
 from tempfile import mkstemp, mkdtemp
 from shutil import rmtree
 
@@ -36,11 +35,13 @@ class VsearchTests(TestCase):
     def setUp(self):
         self.output_dir = mkdtemp()
         self.seqs_to_derep = seqs_to_derep
-        self.seqs_to_derep_max_min_abundance = seqs_to_derep_max_min_abundance
-        self.seqs_to_derep_merged_derep_files = seqs_to_derep_merged_derep_files
+        self.seqs_to_derep_max_min_abundance =\
+            seqs_to_derep_max_min_abundance
+        self.seqs_to_derep_merged_derep_files =\
+            seqs_to_derep_merged_derep_files
         self.seqs_to_sort = seqs_to_sort
         self.amplicon_reads = amplicon_reads
-        self.single_chimera = single_chimera 
+        self.single_chimera = single_chimera
         self.single_chimera_ref = single_chimera_ref
         self.uchime_ref_db = uchime_ref_db
         self.uchime_single_ref_db = uchime_single_ref_db
@@ -55,8 +56,9 @@ class VsearchTests(TestCase):
             tmp.write(self.seqs_to_derep)
 
         # temporary file for seqs_to_derep_max_min_abundance
-        f, self.seqs_to_derep_max_min_abundance_fp = mkstemp(prefix='tmp_seqs_to_derep_abun_',
-                                                             suffix='.fasta')
+        f, self.seqs_to_derep_max_min_abundance_fp =\
+            mkstemp(prefix='tmp_seqs_to_derep_abun_',
+                    suffix='.fasta')
         close(f)
 
         # write seqs_to_derep_max_min_abundance to file
@@ -64,8 +66,9 @@ class VsearchTests(TestCase):
             tmp.write(self.seqs_to_derep_max_min_abundance)
 
         # temporary file for seqs_to_derep_merged_derep_files
-        f, self.seqs_to_derep_merged_derep_files_fp = mkstemp(prefix='tmp_seqs_to_derep_concat_',
-                                                              suffix='.fasta')
+        f, self.seqs_to_derep_merged_derep_files_fp =\
+            mkstemp(prefix='tmp_seqs_to_derep_concat_',
+                    suffix='.fasta')
         close(f)
 
         # write seqs_to_derep_merged_derep_files to file
@@ -104,7 +107,7 @@ class VsearchTests(TestCase):
         f, self.single_chimera_ref_fp = mkstemp(prefix='tmp_single_chimera_',
                                                 suffix='.fasta')
         close(f)
-        
+
         # write single_chimera_ref to file
         # (reference chimera checking)
         with open(self.single_chimera_ref_fp, 'w') as tmp:
@@ -118,10 +121,11 @@ class VsearchTests(TestCase):
         # write uchime_ref_db to file
         with open(self.uchime_ref_db_fp, 'w') as tmp:
             tmp.write(self.uchime_ref_db)
-    
+
         # temporary file for uchime_single_ref_db
-        f, self.uchime_single_ref_db_fp = mkstemp(prefix='tmp_uchime_single_ref_db_',
-                                                  suffix='.fasta')
+        f, self.uchime_single_ref_db_fp =\
+            mkstemp(prefix='tmp_uchime_single_ref_db_',
+                    suffix='.fasta')
         close(f)
 
         # write uchime_single_ref_db to file
@@ -149,15 +153,15 @@ class VsearchTests(TestCase):
         """
         chimeras_fp, nonchimeras_fp, alns_fp, tabular_fp =\
             vsearch_chimera_filter_ref(
-            self.amplicon_reads_fp,
-            self.output_dir,
-            self.uchime_ref_db_fp,
-            output_chimeras=True,
-            output_nonchimeras=False,
-            output_alns=False,
-            output_tabular=False,
-            log_name="vsearch_uchime_ref_chimera_filtering.log",
-            HALT_EXEC=False)
+                self.amplicon_reads_fp,
+                self.output_dir,
+                self.uchime_ref_db_fp,
+                output_chimeras=True,
+                output_nonchimeras=False,
+                output_alns=False,
+                output_tabular=False,
+                log_name="vsearch_uchime_ref_chimera_filtering.log",
+                HALT_EXEC=False)
 
         self.assertTrue(nonchimeras_fp is None)
         self.assertTrue(alns_fp is None)
@@ -185,7 +189,7 @@ class VsearchTests(TestCase):
 
     def test_vsearch_chimera_filter_ref_output(self):
         """ Raise error when no output is selected for
-            reference chimera filtering 
+            reference chimera filtering
         """
 
         self.assertRaises(ValueError,
@@ -201,19 +205,19 @@ class VsearchTests(TestCase):
                           HALT_EXEC=False)
 
     def test_vsearch_chimera_filter_ref_output_nonchimeras(self):
-        """ Test ref chimera filter, output nonchimeric sequences                                                               
+        """ Test ref chimera filter, output nonchimeric sequences
         """
         chimeras_fp, nonchimeras_fp, alns_fp, tabular_fp =\
             vsearch_chimera_filter_ref(
-            self.amplicon_reads_fp,
-            self.output_dir,
-            self.uchime_ref_db_fp,
-            output_chimeras=False,
-            output_nonchimeras=True,
-            output_alns=False,
-            output_tabular=False,
-            log_name="vsearch_uchime_ref_chimera_filtering.log",
-            HALT_EXEC=False)
+                self.amplicon_reads_fp,
+                self.output_dir,
+                self.uchime_ref_db_fp,
+                output_chimeras=False,
+                output_nonchimeras=True,
+                output_alns=False,
+                output_tabular=False,
+                log_name="vsearch_uchime_ref_chimera_filtering.log",
+                HALT_EXEC=False)
 
         self.assertTrue(chimeras_fp is None)
         self.assertTrue(alns_fp is None)
@@ -274,15 +278,15 @@ class VsearchTests(TestCase):
         """
         chimeras_fp, nonchimeras_fp, alns_fp, tabular_fp =\
             vsearch_chimera_filter_ref(
-            self.single_chimera_ref_fp,
-            self.output_dir,
-            self.uchime_single_ref_db_fp,
-            output_chimeras=False,
-            output_nonchimeras=False,
-            output_alns=True,
-            output_tabular=True,
-            log_name="vsearch_uchime_ref_chimera_filtering.log",
-            HALT_EXEC=False)
+                self.single_chimera_ref_fp,
+                self.output_dir,
+                self.uchime_single_ref_db_fp,
+                output_chimeras=False,
+                output_nonchimeras=False,
+                output_alns=True,
+                output_tabular=True,
+                log_name="vsearch_uchime_ref_chimera_filtering.log",
+                HALT_EXEC=False)
 
         self.assertTrue(chimeras_fp is None)
         self.assertTrue(nonchimeras_fp is None)
@@ -304,14 +308,14 @@ class VsearchTests(TestCase):
         """
         chimeras_fp, nonchimeras_fp, alns_fp, tabular_fp =\
             vsearch_chimera_filter_de_novo(
-            self.amplicon_reads_fp,
-            self.output_dir,
-            output_chimeras=True,
-            output_nonchimeras=False,
-            output_alns=False,
-            output_tabular=False,
-            log_name="vsearch_uchime_de_novo_chimera_filtering.log",
-            HALT_EXEC=False)
+                self.amplicon_reads_fp,
+                self.output_dir,
+                output_chimeras=True,
+                output_nonchimeras=False,
+                output_alns=False,
+                output_tabular=False,
+                log_name="vsearch_uchime_de_novo_chimera_filtering.log",
+                HALT_EXEC=False)
 
         self.assertTrue(nonchimeras_fp is None)
         self.assertTrue(alns_fp is None)
@@ -329,7 +333,7 @@ class VsearchTests(TestCase):
 
         with open(chimeras_fp, "U") as chimeras_f:
             for label, seq in parse_fasta(chimeras_f):
-                # check label represents chimeric sequence                                                           
+                # check label represents chimeric sequence
                 self.assertTrue(label in expected_chimeras)
                 # check sequence exists
                 self.assertTrue(len(seq) > 0)
@@ -350,7 +354,7 @@ class VsearchTests(TestCase):
                           output_nonchimeras=False,
                           output_alns=False,
                           output_tabular=False,
-                          log_name="vsearch_uchime_de_novo_chimera_filtering.log",
+                          log_name="vsearch_uchime_de_novo_chimera_filter.log",
                           HALT_EXEC=False)
 
     def test_vsearch_chimera_filter_de_novo_output_nonchimeras(self):
@@ -358,14 +362,14 @@ class VsearchTests(TestCase):
         """
         chimeras_fp, nonchimeras_fp, alns_fp, tabular_fp =\
             vsearch_chimera_filter_de_novo(
-            self.amplicon_reads_fp,
-            self.output_dir,
-            output_chimeras=False,
-            output_nonchimeras=True,
-            output_alns=False,
-            output_tabular=False,
-            log_name="vsearch_uchime_de_novo_chimera_filtering.log",
-            HALT_EXEC=False)
+                self.amplicon_reads_fp,
+                self.output_dir,
+                output_chimeras=False,
+                output_nonchimeras=True,
+                output_alns=False,
+                output_tabular=False,
+                log_name="vsearch_uchime_de_novo_chimera_filter.log",
+                HALT_EXEC=False)
 
         self.assertTrue(chimeras_fp is None)
         self.assertTrue(alns_fp is None)
@@ -422,18 +426,18 @@ class VsearchTests(TestCase):
 
     def test_vsearch_chimera_filter_de_novo_output_alns_tab(self):
         """ Test de novo chimera filter, output only
-            chimeric alignments and tabular format                                                  
+            chimeric alignments and tabular format
         """
         chimeras_fp, nonchimeras_fp, alns_fp, tabular_fp =\
             vsearch_chimera_filter_de_novo(
-            self.single_chimera_fp,
-            self.output_dir,
-            output_chimeras=False,
-            output_nonchimeras=False,
-            output_alns=True,
-            output_tabular=True,
-            log_name="vsearch_uchime_de_novo_chimera_filtering.log",
-            HALT_EXEC=False)
+                self.single_chimera_fp,
+                self.output_dir,
+                output_chimeras=False,
+                output_nonchimeras=False,
+                output_alns=True,
+                output_tabular=True,
+                log_name="vsearch_uchime_de_novo_chimera_filter.log",
+                HALT_EXEC=False)
 
         self.assertTrue(chimeras_fp is None)
         self.assertTrue(nonchimeras_fp is None)
@@ -449,7 +453,7 @@ class VsearchTests(TestCase):
         self.assertEquals(single_chimera_tab, actual_tab)
 
     def test_vsearch_sort_by_abundance(self):
-        """ Test sorting sequences by abundance                                                        
+        """ Test sorting sequences by abundance
         """
         tmp_fp = join(self.output_dir, "tmp_sorted_reads.fasta")
 
@@ -473,7 +477,7 @@ class VsearchTests(TestCase):
 
         num_seqs = 0
 
-        with open(tmp_fp, "U") as tmp_f:
+        with open(output_sorted, "U") as tmp_f:
             for label, seq in parse_fasta(tmp_f):
                 # check label is in correct order
                 self.assertEquals(label, expected_order[num_seqs])
@@ -482,7 +486,7 @@ class VsearchTests(TestCase):
                 num_seqs += 1
 
         self.assertTrue(num_seqs, 8)
-        
+
     def test_vsearch_sort_by_abundance_minsize_1_maxsize_10(self):
         """ Test sorting sequences by abundance,
             discard sequences with an abundance value smaller
@@ -507,11 +511,11 @@ class VsearchTests(TestCase):
 
         num_seqs = 0
 
-        with open(tmp_fp, "U") as tmp_f:
+        with open(output_sorted, "U") as tmp_f:
             for label, seq in parse_fasta(tmp_f):
-                # check label is in correct order                                                                                    
+                # check label is in correct order
                 self.assertEquals(label, expected_order[num_seqs])
-                # check sequence exists                                                                                              
+                # check sequence exists
                 self.assertTrue(len(seq) > 0)
                 num_seqs += 1
 
@@ -575,10 +579,10 @@ class VsearchTests(TestCase):
         id_to_count = {}
 
         num_seqs = 0
-        expected_derep = {'HWI-ST157_0368:1:1207:16180:126921#0/1':3,
-                          'HWI-ST157_0368:1:2103:7895:197066#0/1':3,
-                          'HWI-ST157_0368:1:1106:11378:83198#0/1':1,
-                          'HWI-ST157_0368:1:2102:15078:69955#0/1':1}
+        expected_derep = {'HWI-ST157_0368:1:1207:16180:126921#0/1': 3,
+                          'HWI-ST157_0368:1:2103:7895:197066#0/1': 3,
+                          'HWI-ST157_0368:1:1106:11378:83198#0/1': 1,
+                          'HWI-ST157_0368:1:2102:15078:69955#0/1': 1}
 
         with open(uc_fp, 'U') as uc_f:
             for line in uc_f:
@@ -591,13 +595,13 @@ class VsearchTests(TestCase):
                 elif line.startswith('H'):
                     seed = line.strip().split('\t')[9]
                     id_to_count[seed] += 1
-                    
+
         # check there are 4 sequences after dereplication
         self.assertEquals(num_seqs, 4)
 
         for label in id_to_count:
             self.assertEquals(expected_derep[label], id_to_count[label])
-            
+
     def test_vsearch_dereplicate_exact_seqs_empty_working_dir(self):
         """ Test dereplicating sequences without passing
             a working directory
@@ -718,7 +722,7 @@ class VsearchTests(TestCase):
 
 
 # Test dereplicating sequences using default parameters
-seqs_to_derep=""">HWI-ST157_0368:1:2102:15078:69955#0/1
+seqs_to_derep = """>HWI-ST157_0368:1:2102:15078:69955#0/1
 TACGTAGGGCCCGAGCGTTGTCCGGATTTATTGGGCGTAAAGCGTGCGCAGGCGGTCTGTTAAGTCTGTAGTTAAAGGCTGTGGCTCAACTATGGTTAGTT
 >HWI-ST157_0368:1:2103:7895:197066#0/1
 TACGTAGGGGGCAAGCGTTGTCCGAATTTACTGGGTGTAAAGGGAGCGCAGACGGCACGGCAAGCCAGATGTGAAAGCCCGGGGCTCAACCCCGGGACTGC
@@ -746,7 +750,7 @@ TACGTAGGGGGCAAGCGTTGTCCGAATTTACTGGGTGTAAAGGGAGCGCAGACGGCACGGCAAGCCAGATGTGAAAGCCC
 TACGTAGGTCCCGAGCGTTGTCCGGATTTATTGGGCGTAAAGCGAGCGCAGGCGGATACTTAAGTCTGGTGTGAAAACCTAGGGCTCAACCCTGGGACTGC
 >HWI-ST157_0368:1:1106:11378:83198#0/1;size=1;
 TACGTAGGGAGCAAGCGTTGTCCGGATTTACTGGGTGTAAAGGGTGCGTAGGCGGCTTTGCAAGTCAGATGTGAAATCTATGGGCTCAACCCATAAACTGC
->HWI-ST157_0368:1:2102:15078:69955#1/1;size=1;                                                    
+>HWI-ST157_0368:1:2102:15078:69955#1/1;size=1;
 TACGTAGGGCCCGAGCGTTGTCCGGATTTATTGGGCGTAAAGCGTGCGCAGGCGGTCTGTTAAGTCTGTAGTTAAAGGCTGTGGCTCAACTATGGTTAGTT
 >HWI-ST157_0368:1:2103:7895:197066#1/1;size=3;
 TACGTAGGGGGCAAGCGTTGTCCGAATTTACTGGGTGTAAAGGGAGCGCAGACGGCACGGCAAGCCAGATGTGAAAGCCCGGGGCTCAACCCCGGGACTGC
@@ -815,7 +819,7 @@ TACGTAGGTCCCGAGCGTTATCCGGATTTACTGGGCGTAAAGGGAGCGTAGGCGGATGATTAAGTGGGATGTGAAATACC
 """
 
 # Test sort by abundance functionality in VSEARCH
-seqs_to_sort=""">HWI-ST157_0368:1:2105:3428:36721#0/1;size=5;
+seqs_to_sort = """>HWI-ST157_0368:1:2105:3428:36721#0/1;size=5;
 TACGTAGGGTGCAAGCGTTATCCGGAATTATTGGGCGTAAAGGGCTCGTAGGCGGTTCGTCGCGTCCGGTGTGAAAGTCCATCGCTTAACGGTGGATCTGC
 >HWI-ST157_0368:1:2106:18272:88408#0/1;size=2;
 TACGTAGGGGGCAAGCGTTATCCGGATTTACTGGGTGTAAAGGGAGCGTAGACGGCGGAGCAAGTCTGAAGTGAAAGCCCGGGGCTCAACCCCGGGACTGC
@@ -860,7 +864,7 @@ TGCATTTTCTCTTATCGAAAACCTTCAGCGTTCTGATCTGAATCCCGTCGAAGAGGCTAAGGGCTATCGCCAACTCATTG
 #       >918 reference=814974,4370324 amplicon=479..769,488..779 position=1..150
 #       >941 reference=579954,4304512 amplicon=488..779,451..742 position=1..150
 #       are chimeric
-amplicon_reads=""">3;size=102;
+amplicon_reads = """>3;size=102;
 GTGCCAGCAGCCGCGGTAATACATAGGTCACAAGCGTTATCCGGATTTATTGGGCGTAAAGCGTTCGTAGGCGGTTTGTT
 AAGTCTAGAGTTAAAGCCTGGGGTTCAACCCCAGCCCGCTTTGGATACTGACAAACTAGAGTTACATAGA
 >16;size=95;
@@ -1479,7 +1483,7 @@ single_chimera_tab = """0.0000\t22;size=93;\t*\t*\t*\t*\t*\t*\t*\t*\t0\t0\t0\t0\
 # Single chimeric sequence for reference chimera checking
 single_chimera_ref = """>251;size=2;
 GTGCCAGCAGCCGCGGTAATACGGAGGATGCGAGCGTTATCCGGATTTATTGGGTTTAAAGGGTGCGTAGGCGGAATGGT
-AAGTCAGTGGTGAAATCCTGCAGCTCAACTGTAGAGTTGCCATTGATACTGGTATACTTGAGTGTTGTAA 
+AAGTCAGTGGTGAAATCCTGCAGCTCAACTGTAGAGTTGCCATTGATACTGGTATACTTGAGTGTTGTAA
 """
 
 # Reference database for UCHIME ref

--- a/bfillings/tests/test_vsearch.py
+++ b/bfillings/tests/test_vsearch.py
@@ -8,8 +8,8 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 # -----------------------------------------------------------------------------
 """
-Unit tests for the VSEARCH version 1.0.10 Application controller
-================================================================
+Unit tests for the VSEARCH version 1.1.1 Application controller
+===============================================================
 """
 
 
@@ -30,7 +30,7 @@ from bfillings.vsearch import (vsearch_dereplicate_exact_seqs,
 
 # Test class and cases
 class VsearchTests(TestCase):
-    """ Tests for VSEARCH version 1.0.10 functionality """
+    """ Tests for VSEARCH version 1.1.1 functionality """
 
     def setUp(self):
         self.output_dir = mkdtemp()
@@ -149,9 +149,9 @@ class VsearchTests(TestCase):
 
     def test_vsearch_chimera_filter_ref(self):
         """ Test reference chimera filter, output only
-            chimeric sequences
+            chimeric sequences and log
         """
-        chimeras_fp, nonchimeras_fp, alns_fp, tabular_fp =\
+        chimeras_fp, nonchimeras_fp, alns_fp, tabular_fp, log_fp =\
             vsearch_chimera_filter_ref(
                 self.amplicon_reads_fp,
                 self.output_dir,
@@ -166,6 +166,7 @@ class VsearchTests(TestCase):
         self.assertTrue(nonchimeras_fp is None)
         self.assertTrue(alns_fp is None)
         self.assertTrue(tabular_fp is None)
+        self.assertTrue(exists(log_fp))
 
         expected_chimeras = ['251;size=2;', '320;size=2;', '36;size=2;',
                              '672;size=2;', '142;size=1;', '201;size=1;',
@@ -207,7 +208,7 @@ class VsearchTests(TestCase):
     def test_vsearch_chimera_filter_ref_output_nonchimeras(self):
         """ Test ref chimera filter, output nonchimeric sequences
         """
-        chimeras_fp, nonchimeras_fp, alns_fp, tabular_fp =\
+        chimeras_fp, nonchimeras_fp, alns_fp, tabular_fp, log_fp =\
             vsearch_chimera_filter_ref(
                 self.amplicon_reads_fp,
                 self.output_dir,
@@ -222,6 +223,7 @@ class VsearchTests(TestCase):
         self.assertTrue(chimeras_fp is None)
         self.assertTrue(alns_fp is None)
         self.assertTrue(tabular_fp is None)
+        self.assertTrue(exists(log_fp))
 
         expected_nonchimeras =\
             ['3;size=102;', '16;size=95;', '22;size=93;', '2;size=87;', '39;size=84;',
@@ -276,7 +278,7 @@ class VsearchTests(TestCase):
         """ Test ref chimera filter, output only
             chimeric alignments and tabular format
         """
-        chimeras_fp, nonchimeras_fp, alns_fp, tabular_fp =\
+        chimeras_fp, nonchimeras_fp, alns_fp, tabular_fp, log_fp =\
             vsearch_chimera_filter_ref(
                 self.single_chimera_ref_fp,
                 self.output_dir,
@@ -290,6 +292,7 @@ class VsearchTests(TestCase):
 
         self.assertTrue(chimeras_fp is None)
         self.assertTrue(nonchimeras_fp is None)
+        self.assertTrue(exists(log_fp))
 
         # check alignment is correct
         with open(alns_fp, 'U') as alns_f:
@@ -306,7 +309,7 @@ class VsearchTests(TestCase):
         """ Test de novo chimera filter, output only
             chimeric sequences
         """
-        chimeras_fp, nonchimeras_fp, alns_fp, tabular_fp =\
+        chimeras_fp, nonchimeras_fp, alns_fp, tabular_fp, log_fp =\
             vsearch_chimera_filter_de_novo(
                 self.amplicon_reads_fp,
                 self.output_dir,
@@ -320,6 +323,7 @@ class VsearchTests(TestCase):
         self.assertTrue(nonchimeras_fp is None)
         self.assertTrue(alns_fp is None)
         self.assertTrue(tabular_fp is None)
+        self.assertTrue(exists(log_fp))
 
         expected_chimeras = ['251;size=2;', '320;size=2;', '36;size=2;',
                              '672;size=2;', '142;size=1;', '201;size=1;',
@@ -360,7 +364,7 @@ class VsearchTests(TestCase):
     def test_vsearch_chimera_filter_de_novo_output_nonchimeras(self):
         """ Test de novo chimera filter, output nonchimeric sequences
         """
-        chimeras_fp, nonchimeras_fp, alns_fp, tabular_fp =\
+        chimeras_fp, nonchimeras_fp, alns_fp, tabular_fp, log_fp =\
             vsearch_chimera_filter_de_novo(
                 self.amplicon_reads_fp,
                 self.output_dir,
@@ -374,6 +378,7 @@ class VsearchTests(TestCase):
         self.assertTrue(chimeras_fp is None)
         self.assertTrue(alns_fp is None)
         self.assertTrue(tabular_fp is None)
+        self.assertTrue(exists(log_fp))
 
         expected_nonchimeras =\
             ['3;size=102;', '16;size=95;', '22;size=93;', '2;size=87;', '39;size=84;',
@@ -428,7 +433,7 @@ class VsearchTests(TestCase):
         """ Test de novo chimera filter, output only
             chimeric alignments and tabular format
         """
-        chimeras_fp, nonchimeras_fp, alns_fp, tabular_fp =\
+        chimeras_fp, nonchimeras_fp, alns_fp, tabular_fp, log_fp =\
             vsearch_chimera_filter_de_novo(
                 self.single_chimera_fp,
                 self.output_dir,
@@ -441,6 +446,7 @@ class VsearchTests(TestCase):
 
         self.assertTrue(chimeras_fp is None)
         self.assertTrue(nonchimeras_fp is None)
+        self.assertTrue(exists(log_fp))
 
         # check alignment is correct
         with open(alns_fp, 'U') as alns_f:
@@ -457,7 +463,7 @@ class VsearchTests(TestCase):
         """
         tmp_fp = join(self.output_dir, "tmp_sorted_reads.fasta")
 
-        output_sorted = vsearch_sort_by_abundance(
+        output_sorted, log_fp = vsearch_sort_by_abundance(
             self.seqs_to_sort_fp,
             tmp_fp,
             working_dir=None,
@@ -465,6 +471,8 @@ class VsearchTests(TestCase):
             maxsize=None,
             log_name="abundance_sort.log",
             HALT_EXEC=False)
+
+        self.assertTrue(exists(log_fp))
 
         expected_order = ['HWI-ST157_0368:1:2107:19923:3944#0/1;size=100;',
                           'HWI-ST157_0368:1:1201:8401:113582#0/1;size=10;',
@@ -494,7 +502,7 @@ class VsearchTests(TestCase):
         """
         tmp_fp = join(self.output_dir, "tmp_sorted_reads.fasta")
 
-        output_sorted = vsearch_sort_by_abundance(
+        output_sorted, log_fp = vsearch_sort_by_abundance(
             self.seqs_to_sort_fp,
             tmp_fp,
             working_dir=None,
@@ -502,6 +510,8 @@ class VsearchTests(TestCase):
             maxsize=10,
             log_name="abundance_sort.log",
             HALT_EXEC=False)
+
+        self.assertTrue(exists(log_fp))
 
         expected_order = ['HWI-ST157_0368:1:1201:8401:113582#0/1;size=10;',
                           'HWI-ST157_0368:1:2204:20491:181552#0/1;size=10;',
@@ -526,7 +536,7 @@ class VsearchTests(TestCase):
         """
         tmp_fp = join(self.output_dir, "tmp_derep_reads.fasta")
 
-        dereplicated_seqs_fp, uc_fp = vsearch_dereplicate_exact_seqs(
+        dereplicated_seqs_fp, uc_fp, log_fp = vsearch_dereplicate_exact_seqs(
             self.seqs_to_derep_fp,
             tmp_fp,
             output_uc=False,
@@ -539,6 +549,7 @@ class VsearchTests(TestCase):
 
         # no output for .uc
         self.assertTrue(uc_fp is None)
+        self.assertTrue(exists(log_fp))
 
         num_seqs = 0
         expected_derep = ['HWI-ST157_0368:1:1207:16180:126921#0/1;size=3;',
@@ -562,7 +573,7 @@ class VsearchTests(TestCase):
         """
         tmp_fp = join(self.output_dir, "tmp_derep_reads.fasta")
 
-        dereplicated_seqs_fp, uc_fp = vsearch_dereplicate_exact_seqs(
+        dereplicated_seqs_fp, uc_fp, log_fp = vsearch_dereplicate_exact_seqs(
             self.seqs_to_derep_fp,
             tmp_fp,
             output_uc=True,
@@ -575,6 +586,7 @@ class VsearchTests(TestCase):
 
         # .uc exists
         self.assertTrue(exists(uc_fp))
+        self.assertTrue(exists(log_fp))
 
         id_to_count = {}
 
@@ -608,7 +620,7 @@ class VsearchTests(TestCase):
         """
         tmp_fp = join(self.output_dir, "tmp_derep_reads.fasta")
 
-        dereplicated_seqs_fp, uc_fp = vsearch_dereplicate_exact_seqs(
+        dereplicated_seqs_fp, uc_fp, log_fp = vsearch_dereplicate_exact_seqs(
             self.seqs_to_derep_fp,
             tmp_fp,
             output_uc=True,
@@ -618,6 +630,8 @@ class VsearchTests(TestCase):
             minuniquesize=None,
             sizein=False,
             sizeout=True)
+
+        self.assertTrue(exists(log_fp))
 
         # check dereplicated seqs and uc file in the same
         # directory (same path as tmp_fp)
@@ -630,7 +644,7 @@ class VsearchTests(TestCase):
         """
         tmp_fp = join(self.output_dir, "tmp_derep_reads.fasta")
 
-        dereplicated_seqs_fp, uc_fp = vsearch_dereplicate_exact_seqs(
+        dereplicated_seqs_fp, uc_fp, log_fp = vsearch_dereplicate_exact_seqs(
             self.seqs_to_derep_max_min_abundance_fp,
             tmp_fp,
             output_uc=False,
@@ -643,6 +657,7 @@ class VsearchTests(TestCase):
 
         # no output for .uc
         self.assertTrue(uc_fp is None)
+        self.assertTrue(exists(log_fp))
 
         num_seqs = 0
         expected_derep = ['HWI-ST157_0368:1:1106:10560:153880#0/1;size=6;',
@@ -669,7 +684,7 @@ class VsearchTests(TestCase):
         """
         tmp_fp = join(self.output_dir, "tmp_derep_reads.fasta")
 
-        dereplicated_seqs_fp, uc_fp = vsearch_dereplicate_exact_seqs(
+        dereplicated_seqs_fp, uc_fp, log_fp = vsearch_dereplicate_exact_seqs(
             self.seqs_to_derep_merged_derep_files_fp,
             tmp_fp,
             output_uc=False,
@@ -682,6 +697,7 @@ class VsearchTests(TestCase):
 
         # no output for .uc
         self.assertTrue(uc_fp is None)
+        self.assertTrue(exists(log_fp))
 
         num_seqs = 0
         expected_derep = ['HWI-ST157_0368:1:1207:16180:126921#0/1;size=6;',

--- a/bfillings/vsearch.py
+++ b/bfillings/vsearch.py
@@ -1,24 +1,20 @@
 #!/usr/bin/env python
 
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 # Copyright (c) 2015--, biocore development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
 # The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
 """ Application controller for vsearch v1.0.7 """
 
-from os.path import splitext, abspath, join, dirname
-from tempfile import mkstemp
-from shutil import rmtree
+from os.path import abspath, join, dirname
 
-from skbio.parse.sequences import parse_fasta
 from burrito.parameters import ValuedParameter, FlagParameter
 from burrito.util import (CommandLineApplication, ResultPath,
-                          ApplicationError, ApplicationNotFoundError)
-from skbio.util import remove_files
+                          ApplicationError)
 
 
 class Vsearch(CommandLineApplication):
@@ -35,7 +31,7 @@ class Vsearch(CommandLineApplication):
         # Filename for UCLUST-like output
         '--uc': ValuedParameter('--', Name='uc', Delimiter=' ',
                                 IsPath=True),
-        
+
         # Filename for BLAST-like tab-separated output
         '--blast6out': ValuedParameter('--', Name='blast6out', Delimiter=' ',
                                        IsPath=True),
@@ -43,7 +39,7 @@ class Vsearch(CommandLineApplication):
         # ID percent for OTU, by default is 97%
         '--id': ValuedParameter('--', Name='id', Delimiter=' ',
                                 IsPath=False, Value=None),
-        
+
         # ID definition, 0-4=CD-HIT,all,int,MBL,BLAST (default vsearch: 2)
         '--iddef': ValuedParameter('--', Name='iddef',
                                    Delimiter=' ', IsPath=False,
@@ -62,7 +58,7 @@ class Vsearch(CommandLineApplication):
 
         # Take into account the abundance annotations present
         # in the input fasta file
-        '--sizein' : FlagParameter('--', Name='sizein'),
+        '--sizein': FlagParameter('--', Name='sizein'),
 
         # Add abundance annotations to the output fasta files
         '--sizeout': FlagParameter('--', Name='sizeout'),
@@ -76,43 +72,47 @@ class Vsearch(CommandLineApplication):
                                     IsPath=False),
 
         # Discard sequences with an abundance value greater than integer
-        '--maxuniquesize': ValuedParameter('--', Name='maxuniquesize', Delimiter=' ',
-                                           IsPath=False),
+        '--maxuniquesize': ValuedParameter('--', Name='maxuniquesize',
+                                           Delimiter=' ', IsPath=False),
 
         # Discard sequences with an abundance value smaller than integer
-        '--minuniquesize': ValuedParameter('--', Name='minuniquesize', Delimiter=' ',
+        '--minuniquesize': ValuedParameter('--', Name='minuniquesize',
+                                           Delimiter=' ',
                                            IsPath=False),
 
         # Abundance sort sequences in given FASTA file
         '--sortbysize': ValuedParameter('--', Name='sortbysize', Delimiter=' ',
-                                      IsPath=True),
-        
+                                        IsPath=True),
+
         # When using --sortbysize, discard sequences
         # with an abundance value greater than maxsize
-        '--maxsize': ValuedParameter('--', Name='maxsize', Delimiter=' ', IsPath=False),
+        '--maxsize': ValuedParameter('--', Name='maxsize', Delimiter=' ',
+                                     IsPath=False),
 
         # When using --sortbysize, discard sequences
         # with an abundance value smaller than minsize
-        '--minsize': ValuedParameter('--', Name='minsize', Delimiter=' ', IsPath=False),
+        '--minsize': ValuedParameter('--', Name='minsize', Delimiter=' ',
+                                     IsPath=False),
 
         # Output cluster consensus sequences to FASTA file
         '--consout': ValuedParameter('--', Name='consout', Delimiter=' ',
                                      IsPath=True),
 
-        # Chimera detection: min abundance ratio of parent vs chimera (default vsearch: 2.0)
+        # Chimera detection: min abundance ratio of parent vs chimera
+        # (default vsearch: 2.0)
         '--abskew': ValuedParameter('--', Name='abskew', Delimiter=' ',
                                     IsPath=False, Value=None),
         # Detect chimeras de novo
-        '--uchime_denovo': ValuedParameter('--', Name='uchime_denovo', Delimiter=' ',
-                                    IsPath=True),
-        
+        '--uchime_denovo': ValuedParameter('--', Name='uchime_denovo',
+                                           Delimiter=' ', IsPath=True),
+
         # Detect chimeras using a reference database
         '--uchime_ref': ValuedParameter('--', Name='uchime_ref',
                                         Delimiter=' ', IsPath=True),
 
         # Output chimera alignments to 3-way alignment file (filepath)
         '--uchimealns': ValuedParameter('--', Name='uchimealns', Delimiter=' ',
-                                      IsPath=True),
+                                        IsPath=True),
 
         # Output chimeric sequences to file (filepath)
         '--chimeras': ValuedParameter('--', Name='chimeras',
@@ -128,7 +128,7 @@ class Vsearch(CommandLineApplication):
         # Output to chimera info to tab-separated file
         '--uchimeout': ValuedParameter('--', Name='uchimeout', Delimiter=' ',
                                        IsPath=True),
-        
+
         # Number of computation threads to use (1 to 256)
         # note: by default, keep the value set to 1 for all commands
         # since otherwise (if no other value is given) VSEARCH will use
@@ -205,17 +205,15 @@ class Vsearch(CommandLineApplication):
 
         return result
 
-
     def getHelp(self):
         """Method that points to documentation"""
-        help_str =\
-        """
+        help_str = """
         VSEARCH is hosted at:
         https://github.com/torognes/vsearch
 
         The following papers should be cited if this resource is used:
 
-        Paper pending. Please cite the github page in the meanwhile. 
+        Paper pending. Please cite the github page in the meanwhile.
         """
         return help_str
 
@@ -237,7 +235,7 @@ def vsearch_dereplicate_exact_seqs(
 
         Parameters
         ----------
-        
+
         fasta_filepath : string
            input filepath of fasta file to be dereplicated
         output_filepath : string
@@ -356,7 +354,7 @@ def vsearch_sort_by_abundance(
     # set working dir to same directory as the output
     # file (if not provided)
     if not working_dir:
-        working_dir = dirname(output_filepath) 
+        working_dir = dirname(output_filepath)
 
     app = Vsearch(WorkingDir=working_dir, HALT_EXEC=HALT_EXEC)
 
@@ -411,7 +409,7 @@ def vsearch_chimera_filter_de_novo(
            18 fields (see Vsearch user manual)
         HALT_EXEC : boolean, optional
            used for debugging app controller
-           
+
         Return
         ------
 
@@ -447,7 +445,8 @@ def vsearch_chimera_filter_de_novo(
         output_chimera_filepath = join(working_dir, 'uchime_chimeras.fasta')
         app.Parameters['--chimeras'].on(output_chimera_filepath)
     if output_nonchimeras:
-        output_non_chimera_filepath = join(working_dir, 'uchime_non_chimeras.fasta')
+        output_non_chimera_filepath = join(working_dir,
+                                           'uchime_non_chimeras.fasta')
         app.Parameters['--nonchimeras'].on(output_non_chimera_filepath)
     if output_alns:
         output_alns_filepath = join(working_dir, 'uchime_alignments.txt')
@@ -455,7 +454,7 @@ def vsearch_chimera_filter_de_novo(
     if output_tabular:
         output_tabular_filepath = join(working_dir, 'uchime_tabular.txt')
         app.Parameters['--uchimeout'].on(output_tabular_filepath)
-    
+
     app.Parameters['--uchime_denovo'].on(fasta_filepath)
 
     log_filepath = join(working_dir, log_name)
@@ -463,7 +462,7 @@ def vsearch_chimera_filter_de_novo(
     app_result = app()
 
     return output_chimera_filepath, output_non_chimera_filepath,\
-           output_alns_filepath, output_tabular_filepath
+        output_alns_filepath, output_tabular_filepath
 
 
 def vsearch_chimera_filter_ref(
@@ -541,7 +540,8 @@ def vsearch_chimera_filter_ref(
         output_chimera_filepath = join(working_dir, 'uchime_chimeras.fasta')
         app.Parameters['--chimeras'].on(output_chimera_filepath)
     if output_nonchimeras:
-        output_non_chimera_filepath = join(working_dir, 'uchime_non_chimeras.fasta')
+        output_non_chimera_filepath = join(working_dir,
+                                           'uchime_non_chimeras.fasta')
         app.Parameters['--nonchimeras'].on(output_non_chimera_filepath)
     if output_alns:
         output_alns_filepath = join(working_dir, 'uchime_alignments.txt')
@@ -552,11 +552,10 @@ def vsearch_chimera_filter_ref(
 
     app.Parameters['--db'].on(db_filepath)
     app.Parameters['--uchime_ref'].on(fasta_filepath)
-    
+
     log_filepath = join(working_dir, log_name)
 
     app_result = app()
 
     return output_chimera_filepath, output_non_chimera_filepath,\
-           output_alns_filepath, output_tabular_filepath
-
+        output_alns_filepath, output_tabular_filepath

--- a/bfillings/vsearch.py
+++ b/bfillings/vsearch.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # -----------------------------------------------------------------------------
 # Copyright (c) 2015--, biocore development team.
 #
@@ -219,10 +217,7 @@ class Vsearch(CommandLineApplication):
         help_str = """
         VSEARCH is hosted at:
         https://github.com/torognes/vsearch
-
-        The following papers should be cited if this resource is used:
-
-        Paper pending. Please cite the github page in the meanwhile.
+        Please cite the above URL if this wrapper is used in published work.
         """
         return help_str
 

--- a/bfillings/vsearch.py
+++ b/bfillings/vsearch.py
@@ -1,0 +1,518 @@
+#!/opt/python-2.7.3/bin python
+
+#-----------------------------------------------------------------------------
+# Copyright (c) 2015--, biocore development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+""" Application controller for vsearch v1.0.7 """
+
+from os.path import splitext, abspath, join, dirname
+from tempfile import mkstemp
+from shutil import rmtree
+
+from skbio.parse.sequences import parse_fasta
+from burrito.parameters import ValuedParameter, FlagParameter
+from burrito.util import (CommandLineApplication, ResultPath,
+                          ApplicationError, ApplicationNotFoundError)
+from skbio.util import remove_files
+
+
+class Vsearch(CommandLineApplication):
+
+    """ Vsearch ApplicationController """
+
+    _command = 'vsearch'
+    _input_handler = '_input_as_parameters'
+    _parameters = {
+        # Output to specified FASTA file
+        '--output': ValuedParameter('--', Name='output', Delimiter=' ',
+                                    IsPath=True),
+
+        # Filename for UCLUST-like output
+        '--uc': ValuedParameter('--', Name='uc', Delimiter=' ',
+                                IsPath=True),
+        
+        # Filename for BLAST-like tab-separated output
+        '--blast6out': ValuedParameter('--', Name='blast6out', Delimiter=' ',
+                                       IsPath=True),
+
+        # ID percent for OTU, by default is 97%
+        '--id': ValuedParameter('--', Name='id', Delimiter=' ',
+                                IsPath=False, Value="0.97"),
+        
+        # ID definition, 0-4=CD-HIT,all,int,MBL,BLAST (2)
+        '--iddef': ValuedParameter('--', Name='iddef',
+                                   Delimiter=' ', IsPath=False,
+                                   Value="2"),
+
+        # Number of hits to accept and show per strand (1)
+        '--maxaccepts':
+        ValuedParameter('--', Name='maxaccepts', Delimiter=' ', Value="1"),
+
+        # Number of non-matching hits to consider (32)
+        '--maxrejects':
+        ValuedParameter('--', Name='maxrejects', Delimiter=' ', Value="32"),
+
+        # Indicate that input sequences are presorted
+        '--usersort': FlagParameter('--', Name='usersort'),
+
+        # Take into account the abundance annotations present
+        # in the input fasta file
+        '--sizein' : FlagParameter('--', Name='sizein'),
+
+        # Add abundance annotations to the output fasta files
+        '--sizeout': FlagParameter('--', Name='sizeout'),
+
+        # Dereplicate exact sequences in the given FASTA file
+        '--derep_fulllength': ValuedParameter('--', Name='derep_fulllength',
+                                              Delimiter=' ', IsPath=True),
+
+        # Dereplicate plus or both strands (both)
+        '--strand': ValuedParameter('--', Name='strand', Delimiter=' ',
+                                    IsPath=False, Value="both")
+
+        # Discard sequences with an abundance value greater than integer
+        '--maxuniquesize': ValuedParameter('--', Name='maxuniquesize', Delimiter=' ',
+                                           IsPath=False),
+
+        # Discard sequences with an abundance value smaller than integer
+        '--minuniquesize': ValuedParameter('--', Name='minuniquesize', Delimiter=' ',
+                                           IsPath=False),
+
+        # Abundance sort sequences in given FASTA file
+        '--sortbysize': ValuedParameter('--', Name='sortbysize', Delimiter=' ',
+                                      IsPath=True),
+        
+        # When using --sortbysize, discard sequences
+        # with an abundance value greater than maxsize
+        '--maxsize': ValuedParameter('--', Name='maxsize', Delimiter=' ', IsPath=False),
+
+        # When using --sortbysize, discard sequences
+        # with an abundance value smaller than minsize
+        '--misize': ValuedParameter('--', Name='minsize', Delimiter=' ', IsPath=False),
+
+        # Output cluster consensus sequences to FASTA file
+        '--consout': ValuedParameter('--', Name='consout', Delimiter=' ',
+                                     IsPath=True),
+
+        # Chimera detection: min abundance ratio of parent vs chimera (2.0)
+        '--abskew': ValuedParameter('--', Name='abskew', Delimiter=' ',
+                                    IsPath=False, Value="2.0"),
+        # Detect chimeras de novo
+        '--uchime_denovo': ValuedParameter('--', Name='uchime_denovo', Delimiter=' ',
+                                    IsPath=True),
+        
+        # Detect chimeras using a reference database
+        '--uchime_ref': ValuedParameter('--', Name='uchime_ref',
+                                        Delimiter=' ', IsPath=True)
+
+        # Output chimera alignments to 3-way alignment file (filepath)
+        '--uchimealns': ValuedParameter('--', Name='uchimealns', Delimiter=' ',
+                                      IsPath=True),
+
+        # Output chimeric sequences to file (filepath)
+        '--chimeras': ValuedParameter('--', Name='chimeras',
+                                      Delimiter=' ', IsPath=True)
+
+        # Output non-chimera filepath
+        '--nonchimeras': ValuedParameter('--', Name='nonchimeras',
+                                         Delimiter=' ', IsPath=True),
+
+        # Reference database for --uchime_ref
+        '--db': ValuedParameter('--', Name='db', Delimiter=' ', IsPath=True),
+
+        # Output to chimera info to tab-separated file
+        '--uchimeout': ValuedParameter('--', Name='uchimeout', Delimiter=' ',
+                                       IsPath=True),
+        
+        # Number of computation threads to use (1 to 256)
+        '--threads': ValuedParameter('--', Name='threads', Delimiter=' ',
+                                     IsPath=False, Value="1")
+    }
+
+    _suppress_stdout = False
+    _suppress_stderr = False
+
+    def _input_as_parameters(self, data):
+        """ Set the input path (a fasta filepath)
+        """
+        # The list of values which can be passed on a per-run basis
+        allowed_values = ['--uc', '--output', '--sortbysize',
+                          '--consout', '--uchime_denovo',
+                          '--derep_fulllength', '--maxuniquesize',
+                          '--minuniquesize', '--sizein',
+                          '--sizeout', '--strand', '--threads',
+                          '--uchime_ref', '--chimeras',
+                          '--nonchimeras', '--db', '--uchimeout',
+                          '--blast6out', '--abskew',
+                          '--sortbysize', '--maxsize', '--minsize']
+
+        unsupported_parameters = set(data.keys()) - set(allowed_values)
+        if unsupported_parameters:
+            raise ApplicationError(
+                "Unsupported parameter(s) passed when calling vsearch: %s" %
+                ' '.join(unsupported_parameters))
+
+        for v in allowed_values:
+            # turn the parameter off so subsequent runs are not
+            # affected by parameter settings from previous runs
+            self.Parameters[v].off()
+            if v in data:
+                # turn the parameter on if specified by the user
+                self.Parameters[v].on(data[v])
+
+        return ''
+
+    def _get_result_paths(self, data):
+        """ Set the result paths """
+
+        result = {}
+
+        result['Output'] = ResultPath(
+            Path=self.Parameters['--output'].Value,
+            IsWritten=self.Parameters['--output'].isOn())
+
+        result['ClusterFile'] = ResultPath(
+            Path=self.Parameters['--uc'].Value,
+            IsWritten=self.Parameters['--uc'].isOn())
+
+        # uchime 3-way global alignments
+        result['Output_aln'] = ResultPath(
+            Path=self.Parameters['--uchimealns'].Value,
+            IsWritten=self.Parameters['--uchimealns'].isOn())
+
+        # uchime tab-separated format
+        result['Output_tabular'] = ResultPath(
+            Path=self.Parameters['--uchimeout'].Value,
+            IsWritten=self.Parameters['--uchimeout'].isOn())
+
+        # chimeras fasta file output
+        result['Output_chimeras'] = ResultPath(
+            Path=self.Parameters['--chimeras'].Value,
+            IsWritten=self.Parameters['--chimeras'].isOn())
+
+        # nonchimeras fasta file output
+        result['Output_nonchimeras'] = ResultPath(
+            Path=self.Parameters['--nonchimeras'].Value,
+            IsWritten=self.Parameters['--nonchimeras'].isOn())
+
+        return result
+
+
+    def getHelp(self):
+        """Method that points to documentation"""
+        help_str =\
+        """
+        VSEARCH is hosted at:
+        https://github.com/torognes/vsearch
+
+        The following papers should be cited if this resource is used:
+
+        Paper pending. Please cite the github page in the meanwhile. 
+        """
+        return help_str
+
+
+def vsearch_dereplicate_exact_seqs(
+        fasta_filepath,
+        output_filepath,
+        output_uc=False,
+        working_dir=None,
+        strand="both",
+        maxuniquesize=None,
+        minuniquesize=None,
+        sizein=False,
+        sizeout=True,
+        log_name="derep.log",
+        HALT_EXEC=False):
+    """ Generates clusters and fasta file of
+        dereplicated subsequences
+
+        Parameters
+        ----------
+        
+        fasta_filepath : string
+           input filepath of fasta file to be dereplicated
+        output_filepath : string
+           write the dereplicated sequences to output_filepath
+        working_dir : string, optional
+           directory path for storing intermediate output
+        output_uc : boolean, optional
+           uutput dereplication results in a file using a
+           uclust-like format
+        strand : string, optional
+           when searching for strictly identical sequences,
+           check the 'strand' only (default: both) or
+           check the plus strand only
+        maxuniquesize : integer, optional
+           discard sequences with an abundance value greater
+           than maxuniquesize
+        minuniquesize : integer, optional
+           discard sequences with an abundance value smaller
+           than integer
+        sizein : boolean, optional
+           take into account the abundance annotations present in
+           the input fasta file,  (search for the pattern
+           "[>;]size=integer[;]" in sequence headers)
+        sizeout : boolean, optional
+           add abundance annotations to the output fasta file
+           (add the pattern ";size=integer;" to sequence headers)
+        log_name : string, optional
+           specifies log filename
+        HALT_EXEC : boolean, optional
+           used for debugging app controller
+    """
+
+    # write all vsearch output files to same directory
+    # as output_filepath if working_dir is not specified
+    if not working_dir:
+        working_dir = dirname(abspath(output_filepath))
+
+    app = Vsearch(WorkingDir=working_dir, HALT_EXEC=HALT_EXEC)
+
+    log_filepath = join(working_dir, log_name)
+    uc_filepath = None
+    if output_uc:
+        uc_filepath = join(working_dir, 'vsearch_uc_dereplicated.uc')
+        app.Parameters['--uc'].on(uc_filepath)
+
+    if maxuniquesize:
+        app.Parameters['--maxuniquesize'].on(maxuniquesize)
+    if minuniquesize:
+        app.Parameters['--minuniquesize'].on(minuniquesize)
+    if sizein:
+        app.Parameters['--sizein'].on(sizein)
+    if sizeout:
+        app.Parameters['--sizeout'].on(sizeout)
+    if (strand == "both" or strand == "plus"):
+        app.Parameters['--strand'].on(strand)
+    else:
+        raise ValueError("Option --strand accepts only 'both'
+                          or 'plus' values")
+    app.Parameters['--derep_fulllength'].on(fasta_filepath)
+    app.Parameters['--output'].on(output_filepath)
+
+    app_result = app()
+
+    return app_result, output_filepath, uc_filepath
+
+
+def vsearch_sort_by_abundance(
+        fasta_filepath,
+        output_filepath,
+        working_dir=None,
+        minsize=None,
+        maxsize=None,
+        log_name="abundance_sort.log",
+        HALT_EXEC=False):
+    """ Fasta entries are sorted by decreasing abundance
+        (Fasta entries are assumed to be dereplicated with
+        the pattern "[>;]size=integer[;]" present in the
+        read label, ex. use function vsearch_dereplicate_exact_seqs
+        prior to calling this function)
+
+        Parameters
+        ----------
+
+        fasta_filepath : string
+           input fasta file (dereplicated fasta)
+        output_filepath : string
+           output filepath for the sorted sequences in fasta format
+        working_dir : string, optional
+           working directory to store intermediate files
+        minsize : integer, optional
+           discard sequences with an abundance value smaller than
+           minsize
+        maxsize : integer, optional
+           discard sequences with an abundance value greater than
+           maxsize
+        log_name : string, optional
+           log filename
+        HALT_EXEC : boolean, optional
+           used for debugging app controller
+    """
+
+    # set working dir to same directory as the output
+    # file (if not set)
+    if not working_dir:
+        working_dir = os.path.dirname(output_filepath) 
+
+    app = Vsearch(WorkingDir=working_dir, HALT_EXEC=HALT_EXEC)
+
+    log_filepath = join(working_dir, log_name)
+
+    if minsize:
+        app.Parameters['--minsize'].on(minsize)
+
+    if maxsize:
+        app.Parameters['--maxsize'].on(maxsize)
+
+    app.Parameters['--sortbysize'].on(fasta_filepath)
+    app.Parameters['--output'].on(output_filepath)
+
+    app_result = app()
+
+    return app_result, output_filepath
+
+
+def vsearch_chimera_filter_de_novo(
+        fasta_filepath,
+        working_dir,
+        output_chimeras=True,
+        output_nonchimeras=True,
+        output_alns=False,
+        output_tabular=False,
+        log_name="vsearch_uchime_de_novo_chimera_filtering.log",
+        HALT_EXEC=False):
+    """ Detect chimeras present in the fasta-formatted filename,
+        without external references (i.e. de novo). Automatically
+        sort the sequences in filename by decreasing abundance
+        beforehand. Output chimeras and non-chimeras to FASTA files
+        and/or 3-way global alignments and/or tabular output.
+
+        Parameters
+        ----------
+
+        fasta_filepath : string
+           input fasta file (dereplicated fasta)
+        working_dir : string
+           directory path for all output files
+        output_chimeras : boolean, optional
+           output chimeric sequences to file, in fasta format
+        output_nonchimeras : boolean, optional
+           output nonchimeric sequences to file, in fasta format
+        output_alns : boolean, optional
+           output 3-way global alignments (parentA, parentB, chimera)
+           in human readable format to file
+        output_tabular : boolean, optional
+           output results using the uchime tab-separated format of
+           18 fields (see Vsearch user manual)
+        HALT_EXEC : boolean, optional
+           used for debugging app controller
+    """
+
+    app = Vsearch(WorkingDir=working_dir, HALT_EXEC=HALT_EXEC)
+
+    if not (output_chimeras or
+            output_nonchimeras or
+            output_alns or
+            output_tabular):
+        raise ValueError("At least one output format (output_chimeras,
+                          output_nonchimeras, output_alns, output_tabular)
+                          must be selected")
+
+    output_chimera_filepath = None
+    output_non_chimera_filepath = None
+    output_alns_filepath = None
+    output_tabular_filepath = None
+
+    # set output filepaths
+    if output_chimeras:
+        output_chimera_filepath = join(working_dir, 'uchime_chimeras.fasta')
+        app.Parameters['--chimeras'].on(output_chimera_filepath)
+    if output_nonchimeras:
+        output_non_chimera_filepath = join(working_dir, 'uchime_non_chimeras.fasta')
+        app.Parameters['--nonchimeras'].on(output_non_chimera_filepath)
+    if output_alns:
+        output_alns_filepath = join(working_dir, 'uchime_alignments.txt')
+        app.Parameters['--uchimealns'].on(output_alns_filepath)
+    if output_tabular:
+        output_tabular_filepath = join(working_dir, 'uchime_tabular.txt')
+        app.Parameters['--uchimeout'].on(output_tabular_filepath)
+    
+    app.Parameters['--uchime_denovo'].on(fasta_filepath)
+
+    log_filepath = join(working_dir, log_name)
+
+    app_result = app()
+
+    return app_result, output_chimera_filepath,
+           output_non_chimera_filepath, output_alns_filepath,
+           output_tabular_filepath
+
+
+def vsearch_chimera_filter_ref(
+        fasta_filepath,
+        working_dir,
+        db_filepath,
+        output_chimeras=True,
+        output_nonchimeras=True,
+        output_alns=False,
+        output_tabular=False,
+        log_name="vsearch_uchime_ref_chimera_filtering.log",
+        threads=1,
+        HALT_EXEC=False):
+    """ Detect chimeras present in the fasta-formatted filename,
+        with an external reference (i.e. database). Output
+        chimeras and non-chimeras to FASTA files and/or 3-way
+        global alignments and/or tabular output.
+
+        Parameters
+        ----------
+
+        fasta_filepath : string
+           input fasta file (dereplicated fasta)
+        working_dir : string
+           directory path for all output files
+        db_filepath : string
+           filepath to reference database
+        output_chimeras : boolean, optional
+           output chimeric sequences to file, in fasta format
+        output_nonchimeras : boolean, optional
+           output nonchimeric sequences to file, in fasta format
+        output_alns : boolean, optional
+           output 3-way global alignments (parentA, parentB, chimera)
+           in human readable format to file
+        output_tabular : boolean, optional
+           output results using the uchime tab-separated format of
+           18 fields (see Vsearch user manual)
+        threads : integer, optional
+           number of computation threads to use (1 to 256)
+        HALT_EXEC : boolean, optional
+           used for debugging app controller
+    """
+
+    app = Vsearch(WorkingDir=working_dir, HALT_EXEC=HALT_EXEC)
+
+    if not (output_chimeras or
+            output_nonchimeras or
+            output_alns or
+            output_tabular):
+        raise ValueError("At least one output format (output_chimeras,
+                          output_nonchimeras, output_alns, output_tabular)
+                          must be selected")
+
+    output_chimera_filepath = None
+    output_non_chimera_filepath = None
+    output_alns_filepath = None
+    output_tabular_filepath = None
+
+    # set output filepaths
+    if output_chimeras:
+        output_chimera_filepath = join(working_dir, 'uchime_chimeras.fasta')
+        app.Parameters['--chimeras'].on(output_chimera_filepath)
+    if output_nonchimeras:
+        output_non_chimera_filepath = join(working_dir, 'uchime_non_chimeras.fasta')
+        app.Parameters['--nonchimeras'].on(output_non_chimera_filepath)
+    if output_alns:
+        output_alns_filepath = join(working_dir, 'uchime_alignments.txt')
+        app.Parameters['--uchimealns'].on(output_alns_filepath)
+    if output_tabular:
+        output_tabular_filepath = join(working_dir, 'uchime_tabular.txt')
+        app.Parameters['--uchimeout'].on(output_tabular_filepath)
+
+    app.Parameters['--db'].on(db_filepath)
+    app.Parameters['--uchime_ref'].on(fasta_filepath)
+    
+    log_filepath = join(working_dir, log_name)
+
+    app_result = app()
+
+    return app_result, output_chimera_filepath,
+           output_non_chimera_filepath, output_alns_filepath,
+           output_tabular_filepath
+

--- a/bfillings/vsearch.py
+++ b/bfillings/vsearch.py
@@ -8,7 +8,7 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 # -----------------------------------------------------------------------------
 
-""" Application controller for vsearch v1.0.7 """
+""" Application controller for vsearch v1.0.10 """
 
 from os.path import abspath, join, dirname
 
@@ -219,17 +219,17 @@ class Vsearch(CommandLineApplication):
 
 
 def vsearch_dereplicate_exact_seqs(
-        fasta_filepath,
-        output_filepath,
-        output_uc=False,
-        working_dir=None,
-        strand="both",
-        maxuniquesize=None,
-        minuniquesize=None,
-        sizein=False,
-        sizeout=True,
-        log_name="derep.log",
-        HALT_EXEC=False):
+    fasta_filepath,
+    output_filepath,
+    output_uc=False,
+    working_dir=None,
+    strand="both",
+    maxuniquesize=None,
+    minuniquesize=None,
+    sizein=False,
+    sizeout=True,
+    log_name="derep.log",
+    HALT_EXEC=False):
     """ Generates clusters and fasta file of
         dereplicated subsequences
 
@@ -311,13 +311,13 @@ def vsearch_dereplicate_exact_seqs(
 
 
 def vsearch_sort_by_abundance(
-        fasta_filepath,
-        output_filepath,
-        working_dir=None,
-        minsize=None,
-        maxsize=None,
-        log_name="abundance_sort.log",
-        HALT_EXEC=False):
+    fasta_filepath,
+    output_filepath,
+    working_dir=None,
+    minsize=None,
+    maxsize=None,
+    log_name="abundance_sort.log",
+    HALT_EXEC=False):
     """ Fasta entries are sorted by decreasing abundance
         (Fasta entries are assumed to be dereplicated with
         the pattern "[>;]size=integer[;]" present in the
@@ -375,14 +375,14 @@ def vsearch_sort_by_abundance(
 
 
 def vsearch_chimera_filter_de_novo(
-        fasta_filepath,
-        working_dir,
-        output_chimeras=True,
-        output_nonchimeras=True,
-        output_alns=False,
-        output_tabular=False,
-        log_name="vsearch_uchime_de_novo_chimera_filtering.log",
-        HALT_EXEC=False):
+    fasta_filepath,
+    working_dir,
+    output_chimeras=True,
+    output_nonchimeras=True,
+    output_alns=False,
+    output_tabular=False,
+    log_name="vsearch_uchime_de_novo_chimera_filtering.log",
+    HALT_EXEC=False):
     """ Detect chimeras present in the fasta-formatted filename,
         without external references (i.e. de novo). Automatically
         sort the sequences in filename by decreasing abundance
@@ -466,16 +466,16 @@ def vsearch_chimera_filter_de_novo(
 
 
 def vsearch_chimera_filter_ref(
-        fasta_filepath,
-        working_dir,
-        db_filepath,
-        output_chimeras=True,
-        output_nonchimeras=True,
-        output_alns=False,
-        output_tabular=False,
-        log_name="vsearch_uchime_ref_chimera_filtering.log",
-        threads=1,
-        HALT_EXEC=False):
+    fasta_filepath,
+    working_dir,
+    db_filepath,
+    output_chimeras=True,
+    output_nonchimeras=True,
+    output_alns=False,
+    output_tabular=False,
+    log_name="vsearch_uchime_ref_chimera_filtering.log",
+    threads=1,
+    HALT_EXEC=False):
     """ Detect chimeras present in the fasta-formatted filename,
         with an external reference (i.e. database). Output
         chimeras and non-chimeras to FASTA files and/or 3-way


### PR DESCRIPTION
This app controller was tested with VSEARCH 1.1.1 version.
Supported functionalities are sequence dereplication + singleton removal, sorting by abundance and chimera detection with the UCHIME algorithm.
It requires the executable 'vsearch' to be in the $PATH variable.
The option to record a log file was added in vsearch.py although not currently used, it is for future support (see this [issue](https://github.com/torognes/vsearch/issues/49)).