### PR TITLE
cleaned up usage of /tmp in application controllers most frequently used by QIIME

### DIFF
--- a/bfillings/blast.py
+++ b/bfillings/blast.py
@@ -12,6 +12,7 @@ from string import strip
 from os import remove, access, F_OK, environ, path
 from random import choice
 from copy import copy
+import tempfile
 
 from burrito.parameters import FlagParameter, ValuedParameter, MixedParameter
 from burrito.util import (CommandLineApplication, ResultPath,
@@ -675,7 +676,7 @@ def fasta_cmd_get_seqs(acc_list,
                  is_protein=None,
                  out_filename=None,
                  params={},
-                 WorkingDir="/tmp",
+                 WorkingDir=tempfile.gettempdir(),
                  SuppressStderr=None,
                  SuppressStdout=None):
     """Retrieve sequences for list of accessions """
@@ -1017,7 +1018,8 @@ def ids_from_seqs_iterative(seqs, app, query_parser, \
 
 
 def blastp(seqs, blast_db="nr", e_value="1e-20", max_hits=200,
-           working_dir="/tmp", blast_mat_root=None, extra_params={}):
+           working_dir=tempfile.gettempdir(), blast_mat_root=None,
+           extra_params={}):
     """
     Returns BlastResult from input seqs, using blastp.
 
@@ -1064,7 +1066,8 @@ def blastp(seqs, blast_db="nr", e_value="1e-20", max_hits=200,
     return None
 
 def blastn(seqs, blast_db="nt", e_value="1e-20", max_hits=200,
-           working_dir="/tmp", blast_mat_root=None, extra_params={}):
+           working_dir=tempfile.gettempdir(), blast_mat_root=None,
+           extra_params={}):
     """
     Returns BlastResult from input seqs, using blastn.
 

--- a/bfillings/muscle_v38.py
+++ b/bfillings/muscle_v38.py
@@ -11,6 +11,7 @@
 """
 from os import remove
 from random import choice
+import tempfile
 
 from skbio.parse.sequences import parse_fasta
 from burrito.parameters import FlagParameter, ValuedParameter
@@ -341,7 +342,7 @@ def muscle_seqs(seqs,
                  out_filename=None,
                  input_handler=None,
                  params={},
-                 WorkingDir=None,
+                 WorkingDir=tempfile.gettempdir(),
                  SuppressStderr=None,
                  SuppressStdout=None):
     """Muscle align list of sequences.
@@ -399,7 +400,7 @@ def cluster_seqs(seqs,
                  neighbor_join=False,
                  params={},
                  add_seq_names=True,
-                 WorkingDir=None,
+                 WorkingDir=tempfile.gettempdir(),
                  SuppressStderr=None,
                  SuppressStdout=None,
                  max_chars=1000000,
@@ -458,7 +459,7 @@ def aln_tree_seqs(seqs,
                  tree_type='neighborjoining',
                  params={},
                  add_seq_names=True,
-                 WorkingDir=None,
+                 WorkingDir=tempfile.gettempdir(),
                  SuppressStderr=None,
                  SuppressStdout=None,
                  max_hours=5.0,
@@ -501,7 +502,7 @@ def fastest_aln_seqs(seqs,
                  params={},
                  out_filename=None,
                  add_seq_names=True,
-                 WorkingDir=None,
+                 WorkingDir=tempfile.gettempdir(),
                  SuppressStderr=None,
                  SuppressStdout=None
                  ):
@@ -550,7 +551,7 @@ def align_unaligned_seqs(seqs, moltype=DNA, params=None):
     params.update({'-out':get_tmp_filename()})
     #Create Muscle app.
     app = Muscle(InputHandler='_input_as_multiline_string',\
-                 params=params)
+                 params=params, WorkingDir=tempfile.gettempdir())
     #Get results using int_map as input to app
     res = app(int_map.toFasta())
     #Get alignment as dict out of results
@@ -606,7 +607,7 @@ def build_tree_from_alignment(aln, moltype=DNA, best_tree=False, params=None):
     """
     # Create instance of app controller, enable tree, disable alignment
     app = Muscle(InputHandler='_input_as_multiline_string', params=params, \
-                   WorkingDir='/tmp')
+                   WorkingDir=tempfile.gettempdir())
 
     app.Parameters['-clusteronly'].on()
     app.Parameters['-tree1'].on(get_tmp_filename(app.WorkingDir))
@@ -679,7 +680,8 @@ def add_seqs_to_alignment(seqs, aln, params=None):
     aln_out.close()
 
     #Create Muscle app and get results
-    app = Muscle(InputHandler='_input_as_multifile', params=params)
+    app = Muscle(InputHandler='_input_as_multifile', params=params,
+                 WorkingDir=tempfile.gettempdir())
     res = app((aln_filename, seqs_filename))
 
     #Get alignment as dict out of results
@@ -746,7 +748,8 @@ def align_two_alignments(aln1, aln2, params=None):
     aln2_out.close()
 
     #Create Muscle app and get results
-    app = Muscle(InputHandler='_input_as_multifile', params=params)
+    app = Muscle(InputHandler='_input_as_multifile', params=params,
+                 WorkingDir=tempfile.gettempdir())
     res = app((aln1_filename, aln2_filename))
 
     #Get alignment as dict out of results

--- a/bfillings/rdp_classifier.py
+++ b/bfillings/rdp_classifier.py
@@ -376,7 +376,7 @@ def parse_command_line_parameters(argv=None):
 
 def assign_taxonomy(
         data, min_confidence=0.80, output_fp=None, training_data_fp=None,
-        fixrank=True, max_memory=None, tmp_dir=None):
+        fixrank=True, max_memory=None, tmp_dir=tempfile.gettempdir()):
     """Assign taxonomy to each sequence in data with the RDP classifier
 
         data: open fasta file object or list of fasta lines
@@ -454,7 +454,7 @@ def assign_taxonomy(
 
 def train_rdp_classifier(
         training_seqs_file, taxonomy_file, model_output_dir, max_memory=None,
-        tmp_dir=None):
+        tmp_dir=tempfile.gettempdir()):
     """ Train RDP Classifier, saving to model_output_dir
 
         training_seqs_file, taxonomy_file: file-like objects used to
@@ -488,7 +488,7 @@ def train_rdp_classifier(
 def train_rdp_classifier_and_assign_taxonomy(
         training_seqs_file, taxonomy_file, seqs_to_classify, min_confidence=0.80,
         model_output_dir=None, classification_output_fp=None, max_memory=None,
-        tmp_dir=None):
+        tmp_dir=tempfile.gettempdir()):
     """ Train RDP Classifier and assign taxonomy in one fell swoop
 
     The file objects training_seqs_file and taxonomy_file are used to

--- a/bfillings/sortmerna_v2.py
+++ b/bfillings/sortmerna_v2.py
@@ -25,6 +25,7 @@ Application controller for SortMeRNA version 2.0
 from os.path import split, splitext, dirname, join
 from glob import glob
 import re
+import tempfile
 
 from burrito.util import CommandLineApplication, ResultPath
 from burrito.parameters import ValuedParameter, FlagParameter
@@ -74,6 +75,7 @@ class IndexDB(CommandLineApplication):
 def build_database_sortmerna(fasta_path,
                              max_pos=None,
                              output_dir=None,
+                             temp_dir=tempfile.gettempdir(),
                              HALT_EXEC=False):
     """ Build sortmerna db from fasta_path; return db name
         and list of files created
@@ -124,7 +126,7 @@ def build_database_sortmerna(fasta_path,
     sdb.Parameters['--ref'].on("%s,%s" % (fasta_path, db_name))
 
     # Set temporary directory
-    sdb.Parameters['--tmpdir'].on(output_dir)
+    sdb.Parameters['--tmpdir'].on(temp_dir)
 
     # Override --max_pos parameter
     if max_pos is not None:

--- a/bfillings/tests/test_uclust.py
+++ b/bfillings/tests/test_uclust.py
@@ -14,7 +14,8 @@
 Modified from Daniel McDonald's test_cd_hit.py code on Feb-4-2010 """
 
 from subprocess import Popen, PIPE, STDOUT
-from tempfile import mkstemp
+from tempfile import mkstemp, gettempdir
+from os.path import join
 
 from unittest import TestCase, main
 
@@ -64,8 +65,8 @@ class UclustTests(TestCase):
         _, self.tmp_clstr_filepath = mkstemp(prefix="uclust_test",
                                              suffix=".clstr")
 
-        self.WorkingDir = '/tmp/uclust_test'
-        self.tmpdir = '/tmp/'
+        self.tmpdir = gettempdir()
+        self.WorkingDir = join(self.tmpdir, 'uclust_test')
 
         self.files_to_remove = [self.tmp_unsorted_fasta_filepath,
                                 self.tmp_sorted_fasta_filepath,
@@ -219,6 +220,8 @@ class UclustConvenienceWrappers(TestCase):
         self.uc_lines_overlapping_lib_input_seq_ids = \
             uc_lines_overlapping_lib_input_seq_ids
 
+        self.tmpdir = gettempdir()
+
     def tearDown(self):
         remove_files(self.files_to_remove, error_on_missing=False)
 
@@ -295,14 +298,14 @@ class UclustConvenienceWrappers(TestCase):
         """ Properly generates output filepath names """
 
         uc_res = \
-            get_output_filepaths("/tmp/", "test_seqs.fasta")
+            get_output_filepaths(self.tmpdir, "test_seqs.fasta")
 
-        self.assertEqual(uc_res, "/tmp/test_seqs_clusters.uc")
+        self.assertEqual(uc_res, join(self.tmpdir, "test_seqs_clusters.uc"))
 
     def test_get_output_filepaths_multiple_dots(self):
         """Generates filepath names from names with more than one dot"""
-        obs = get_output_filepaths("/tmp", "test_seqs.filtered.fasta")
-        self.assertEqual(obs, "/tmp/test_seqs.filtered_clusters.uc")
+        obs = get_output_filepaths(self.tmpdir, "test_seqs.filtered.fasta")
+        self.assertEqual(obs, join(self.tmpdir, "test_seqs.filtered_clusters.uc"))
 
     def test_get_clusters_from_fasta_filepath(self):
         """ Tests for return of lists of OTUs from given fasta filepath """

--- a/bfillings/uclust.py
+++ b/bfillings/uclust.py
@@ -505,6 +505,7 @@ def get_clusters_from_fasta_filepath(
         suppress_new_clusters=False,
         return_cluster_maps=False,
         stable_sort=False,
+        tmp_dir=gettempdir(),
         save_uc_files=True,
         HALT_EXEC=False):
     """ Main convenience wrapper for using uclust to generate cluster files
@@ -575,6 +576,7 @@ def get_clusters_from_fasta_filepath(
             subject_fasta_filepath=subject_fasta_filepath,
             suppress_new_clusters=suppress_new_clusters,
             stable_sort=stable_sort,
+            tmp_dir=tmp_dir,
             HALT_EXEC=HALT_EXEC)
         # Get cluster file name from application wrapper
         remove_files(files_to_remove)

--- a/bfillings/usearch.py
+++ b/bfillings/usearch.py
@@ -21,7 +21,7 @@ Greg Caporaso/William Walters
 """
 
 from os.path import splitext, abspath, join
-from tempfile import mkstemp
+from tempfile import mkstemp, gettempdir
 
 from skbio.parse.sequences import parse_fasta
 from burrito.parameters import ValuedParameter, FlagParameter
@@ -1479,7 +1479,7 @@ def usearch_qf(
 def assign_dna_reads_to_database(query_fasta_fp,
                                  database_fasta_fp,
                                  output_fp,
-                                 temp_dir="/tmp",
+                                 temp_dir=gettempdir(),
                                  params={},
                                  blast6_fp=None,
                                  HALT_EXEC=False):


### PR DESCRIPTION
Many of these are in need of overhaul for more consistent temp file handling (among other things) but this is a step toward less use of ``/tmp`` in ``bfillings``. 

Partially addresses #64.