### PR TITLE
REL/MAINT: update for 0.1.1-dev, add cogent dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # burrito-fillings changelog
 
+## Version 0.1.1-dev (changes since 0.1.1 go here)
+
 ## Version 0.1.1 (2015-05-22)
 
 * Updated handling of temporary files to make better use of python ``tempfile.gettempdir()`` for some of the most widely used burrito fillings ([#61](https://github.com/biocore/burrito-fillings/pull/61), [#64](https://github.com/biocore/burrito-fillings/pull/64)).

--- a/bfillings/__init__.py
+++ b/bfillings/__init__.py
@@ -8,4 +8,4 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__version__ = '0.1.1'
+__version__ = '0.1.1-dev'

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-__version__ = '0.1.1'
+__version__ = '0.1.1-dev'
 
 from setuptools import find_packages, setup
 from distutils.command.build_py import build_py
@@ -42,5 +42,7 @@ setup(name='burrito-fillings',
       maintainer_email="gregcaporaso@gmail.com",
       url='https://github.com/biocore/burrito-fillings',
       packages=find_packages(),
-      install_requires=['scikit-bio >= 0.2.1, < 0.3.0', 'burrito  < 1.0.0'],
+      install_requires=['scikit-bio >= 0.2.1, < 0.3.0',
+                        'burrito  < 1.0.0',
+                        'cogent == 1.5.3'],
       classifiers=classifiers)


### PR DESCRIPTION
I tested and confirmed that the setup.py addition now results in cogent being installed. 